### PR TITLE
skip checking the names of src and dst zpools in remote backup

### DIFF
--- a/backupData.sh
+++ b/backupData.sh
@@ -207,6 +207,7 @@ parseInputParams() {
 	
 	# ensure that the ZPOOL of the destination filesystem is different from the
 	# ZPOOL(s) of the source filesystems
+	if [ "$I_REMOTE_ACTIVE" -eq "0" ]; then
 	dest_pool=`echo "$I_DEST_FS" | cut -f1 -d/`
 	for current_fs in $I_SRC_FSS ; do
 		current_src_pool=`echo "$current_fs" | cut -f1 -d/`
@@ -215,6 +216,7 @@ parseInputParams() {
 			return 1
 		fi
 	done
+	fi
 	
 	# Ensure that the number of compression algorithm provided is compatible with
 	# the number of source filesystems


### PR DESCRIPTION
fix the bug which rejects backup when the names of source and destination zpools are same even in remote backup.