### PR TITLE
Convert Tabs characters to Spaces

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -156,7 +156,7 @@ Fixes
 Tested with
 -----------
 
-- NAS4Free  	9.2.0.1 - Shigawire (revision 972) - Embedded
+- NAS4Free 9.2.0.1 - Shigawire (revision 972) - Embedded
 
 v2.0-beta1 (2013-03-25):
 ====

--- a/acpiStats.sh
+++ b/acpiStats.sh
@@ -5,16 +5,16 @@
 #
 # Usage: acpiStats.sh [-p W0,W3,W5]
 #
-# 	-p 	W0: typical power consumption in mW while in ACPI state S0
-# 	 	W3: typical power consumption in mW while in ACPI state S3
-# 	 	W5: typical power consumption in mW while in ACPI state S5
+#     -p W0: typical power consumption in mW while in ACPI state S0
+#        W3: typical power consumption in mW while in ACPI state S3
+#        W5: typical power consumption in mW while in ACPI state S5
 #
 # Author: fritz from NAS4Free forum
 #
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -42,9 +42,9 @@ readonly S_IN_YEAR=31536000
 
 # Initialisation of the default values for the arguments of the script
 I_COMPUTE_CONSUMPTION="0"
-I_W_S0="0"			# Power consumed by the NAS in S0 (in mW)
-I_W_S3="0"			# Power consumed by the NAS in S3 (in mW)
-I_W_S5="0"			# Power consumed by the NAS in S5 (in mW)
+I_W_S0="0"            # Power consumed by the NAS in S0 (in mW)
+I_W_S3="0"            # Power consumed by the NAS in S3 (in mW)
+I_W_S5="0"            # Power consumed by the NAS in S5 (in mW)
 
 
 ##################################
@@ -54,44 +54,44 @@ I_W_S5="0"			# Power consumed by the NAS in S5 (in mW)
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local regex_pow regex_pows opt
+    local regex_pow regex_pows opt
 
-	regex_pow="([1-9][0-9]*)"
-	regex_pows="$regex_pow[,]$regex_pow[,]$regex_pow"
+    regex_pow="([1-9][0-9]*)"
+    regex_pows="$regex_pow[,]$regex_pow[,]$regex_pow"
 
-	# parse the optional arguments
-	while getopts ":p:" opt; do
-	
-		case $opt in
-			p)	echo "$OPTARG" | grep -E "^$regex_pows$" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_COMPUTE_CONSUMPTION="1"	
-					I_W_S0=`echo "$OPTARG" | cut -f1 -d,`			
-					I_W_S3=`echo "$OPTARG" | cut -f2 -d,`			
-					I_W_S5=`echo "$OPTARG" | cut -f3 -d,`			
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -p. Should be \"pS0,pS3,pS5\", were pSx are integer"
-					return 1
-				fi ;;
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-			:)
-				echo "Option -$OPTARG requires an argument"
-				return 1 ;;
+    # parse the optional arguments
+    while getopts ":p:" opt; do
+    
+        case $opt in
+            p)    echo "$OPTARG" | grep -E "^$regex_pows$" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_COMPUTE_CONSUMPTION="1"    
+                    I_W_S0=`echo "$OPTARG" | cut -f1 -d,`            
+                    I_W_S3=`echo "$OPTARG" | cut -f2 -d,`            
+                    I_W_S5=`echo "$OPTARG" | cut -f3 -d,`            
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -p. Should be \"pS0,pS3,pS5\", were pSx are integer"
+                    return 1
+                fi ;;
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            :)
+                echo "Option -$OPTARG requires an argument"
+                return 1 ;;
                 esac
         done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "0" ]; then
-		echo "No mandatory arguments should be provided"
-		return 1
-	fi
-	
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "0" ]; then
+        echo "No mandatory arguments should be provided"
+        return 1
+    fi
+    
         return 0
 }
 
@@ -105,59 +105,59 @@ parseInputParams() {
 ##################################
 compute_stat() {
 
-	local log_file pattern date_format duration duration_tot current_line \
-		nbLinesInFile current_date current_ts current_pattern old_ts old_pattern \
-		log_entry deltat
+    local log_file pattern date_format duration duration_tot current_line \
+        nbLinesInFile current_date current_ts current_pattern old_ts old_pattern \
+        log_entry deltat
 
-	log_file="$1"
-	pattern="$2"
+    log_file="$1"
+    pattern="$2"
 
-	date_format=`ts_format`
-	
-	duration="0"
-	duration_tot="0"
-	
-	current_line="1"
-	
-	nbLinesInFile=`wc -l "$log_file" | awk ' { print $1 } '`	# find number of lines
+    date_format=`ts_format`
+    
+    duration="0"
+    duration_tot="0"
+    
+    current_line="1"
+    
+    nbLinesInFile=`wc -l "$log_file" | awk ' { print $1 } '`    # find number of lines
 
-	# Itterate the file to compute the time spent by the NAS
-	# in the state described by the pattern
-	while [ "$current_line" -le "$nbLinesInFile" ]
-	do
-		old_ts="$current_ts"
-		old_pattern="$current_pattern"
-	
-		log_entry=`sed "$current_line"!d "$log_file"`
+    # Itterate the file to compute the time spent by the NAS
+    # in the state described by the pattern
+    while [ "$current_line" -le "$nbLinesInFile" ]
+    do
+        old_ts="$current_ts"
+        old_pattern="$current_pattern"
+    
+        log_entry=`sed "$current_line"!d "$log_file"`
 
-		# get line data from log file
-		current_date=`echo "$log_entry" | cut -f1`		
-		current_pattern=`echo "$log_entry" | cut -f3`		
-		current_ts=`$BIN_DATE -j -f "$date_format" "$current_date" +%s`
-		
-		# compute duration for pattern
-		if [ "$current_line" -gt "1" ]; then
-			deltat=$(($current_ts-$old_ts))
-			duration_tot=$(($duration_tot+$deltat))
-			if [ "$old_pattern" = "$pattern" ]; then
-				duration=$(($duration+$deltat))
-			fi
-		fi
+        # get line data from log file
+        current_date=`echo "$log_entry" | cut -f1`        
+        current_pattern=`echo "$log_entry" | cut -f3`        
+        current_ts=`$BIN_DATE -j -f "$date_format" "$current_date" +%s`
+        
+        # compute duration for pattern
+        if [ "$current_line" -gt "1" ]; then
+            deltat=$(($current_ts-$old_ts))
+            duration_tot=$(($duration_tot+$deltat))
+            if [ "$old_pattern" = "$pattern" ]; then
+                duration=$(($duration+$deltat))
+            fi
+        fi
 
-		current_line=$(($current_line+1))
-	done
+        current_line=$(($current_line+1))
+    done
 
-	# Take into account the time between the last
-	# timestamp and now
-	old_ts="$current_ts"	
-	current_ts=`$BIN_DATE +%s`	
-	deltat=$(($current_ts-$old_ts))
-	duration_tot=$(($duration_tot+$deltat))
-	if [ "$current_pattern" = "$pattern" ]; then
-		duration=$(($duration+$deltat))
-	fi
+    # Take into account the time between the last
+    # timestamp and now
+    old_ts="$current_ts"    
+    current_ts=`$BIN_DATE +%s`    
+    deltat=$(($current_ts-$old_ts))
+    duration_tot=$(($duration_tot+$deltat))
+    if [ "$current_pattern" = "$pattern" ]; then
+        duration=$(($duration+$deltat))
+    fi
 
-	echo $(($duration*100/$duration_tot))
+    echo $(($duration*100/$duration_tot))
 }
 
 
@@ -170,36 +170,36 @@ compute_stat() {
 # return : 1 if an error occured, 0 otherwise
 ##################################
 log_stats() {
-	local S0p S3p S5p file percentage_tot
+    local S0p S3p S5p file percentage_tot
 
-	file=$1
+    file=$1
 
-	# compute statistics
-	S0p=`compute_stat "$file" "S0"`
-	S3p=`compute_stat "$file" "S3"`
-	S5p=`compute_stat "$file" "S5"`
+    # compute statistics
+    S0p=`compute_stat "$file" "S0"`
+    S3p=`compute_stat "$file" "S3"`
+    S5p=`compute_stat "$file" "S5"`
 
-	if [ "$I_COMPUTE_CONSUMPTION" -eq "1" ]; then 		
-		log_info "$LOGFILE" "S0 ($(($I_W_S0/1000)) W) (Working)       : $S0p percent"
-		log_info "$LOGFILE" "S3 ($(($I_W_S3/1000)) W) (Suspend to RAM): $S3p percent"
-		log_info "$LOGFILE" "S5 ($(($I_W_S5/1000)) W) (Soft off)      : $S5p percent"
-		W_average=$((($I_W_S0*$S0p+$I_W_S3*$S3p+$I_W_S5*$S5p)/100/1000))
-		log_info "$LOGFILE" "Average power comsumption: $W_average W"
-	else
-		log_info "$LOGFILE" "S0 (Working)       : $S0p percent"
-		log_info "$LOGFILE" "S3 (Suspend to RAM): $S3p percent"
-		log_info "$LOGFILE" "S5 (Soft off)      : $S5p percent"
-	fi
+    if [ "$I_COMPUTE_CONSUMPTION" -eq "1" ]; then         
+        log_info "$LOGFILE" "S0 ($(($I_W_S0/1000)) W) (Working)       : $S0p percent"
+        log_info "$LOGFILE" "S3 ($(($I_W_S3/1000)) W) (Suspend to RAM): $S3p percent"
+        log_info "$LOGFILE" "S5 ($(($I_W_S5/1000)) W) (Soft off)      : $S5p percent"
+        W_average=$((($I_W_S0*$S0p+$I_W_S3*$S3p+$I_W_S5*$S5p)/100/1000))
+        log_info "$LOGFILE" "Average power comsumption: $W_average W"
+    else
+        log_info "$LOGFILE" "S0 (Working)       : $S0p percent"
+        log_info "$LOGFILE" "S3 (Suspend to RAM): $S3p percent"
+        log_info "$LOGFILE" "S5 (Soft off)      : $S5p percent"
+    fi
 
-	# consistency check
-	percentage_tot=$(($S0p+$S3p+$S5p))	
+    # consistency check
+    percentage_tot=$(($S0p+$S3p+$S5p))    
 
-	if [ $percentage_tot -ge "98" -a $percentage_tot -le "102" ]; then
-		return 0
-	else
-		log_warning "$LOGFILE" "The sum of the percentages is not equal to 100, but equals $percentage_tot"
-		return 1
-	fi
+    if [ $percentage_tot -ge "98" -a $percentage_tot -le "102" ]; then
+        return 0
+    else
+        log_warning "$LOGFILE" "The sum of the percentages is not equal to 100, but equals $percentage_tot"
+        return 1
+    fi
 }
 
 
@@ -207,59 +207,59 @@ log_stats() {
 # Main
 ##################################
 main() {
-	local oldest_acpi_ts
+    local oldest_acpi_ts
 
-	log_info "$LOGFILE" "Starting computation of ACPI statistics"
+    log_info "$LOGFILE" "Starting computation of ACPI statistics"
 
-	oldest_acpi_ts=`get_log_oldest_ts "$ACPI_STATE_LOGFILE"`
-	if [ "$?" -ne "0" ]; then
-		log_error "$LOGFILE" "Could not read \"$ACPI_STATE_LOGFILE\" that should contain the acpi states history"
-		return 1
-	fi
-	
-	if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_WEEK"S +%s` ]; then
-		get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_WEEK" > $TMPFILE
-		log_info "$LOGFILE" "ACPI Statistics for the last week:"
-		if ! log_stats $TMPFILE; then return 1; fi
-	fi
+    oldest_acpi_ts=`get_log_oldest_ts "$ACPI_STATE_LOGFILE"`
+    if [ "$?" -ne "0" ]; then
+        log_error "$LOGFILE" "Could not read \"$ACPI_STATE_LOGFILE\" that should contain the acpi states history"
+        return 1
+    fi
+    
+    if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_WEEK"S +%s` ]; then
+        get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_WEEK" > $TMPFILE
+        log_info "$LOGFILE" "ACPI Statistics for the last week:"
+        if ! log_stats $TMPFILE; then return 1; fi
+    fi
 
-	if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_MONTH"S +%s` ]; then
-		get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_MONTH" > $TMPFILE
-		log_info "$LOGFILE" "ACPI Statistics for the last month:"
-		if ! log_stats $TMPFILE; then return 1; fi
-	fi
+    if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_MONTH"S +%s` ]; then
+        get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_MONTH" > $TMPFILE
+        log_info "$LOGFILE" "ACPI Statistics for the last month:"
+        if ! log_stats $TMPFILE; then return 1; fi
+    fi
 
-	if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_YEAR"S +%s` ]; then
-		get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_YEAR" > $TMPFILE
-		log_info "$LOGFILE" "ACPI Statistics for the last year:"
-		if ! log_stats $TMPFILE; then return 1; fi
-	fi
+    if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_YEAR"S +%s` ]; then
+        get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_YEAR" > $TMPFILE
+        log_info "$LOGFILE" "ACPI Statistics for the last year:"
+        if ! log_stats $TMPFILE; then return 1; fi
+    fi
 
-	cat "$ACPI_STATE_LOGFILE" > $TMPFILE
-	log_info "$LOGFILE" "ACPI Statistics since the beginning of the log (`$BIN_DATE -j -f %s $oldest_acpi_ts`):"
-	if ! log_stats $TMPFILE; then return 1; fi
-		
-	# Delete the temporary file
-	$BIN_RM -f "$TMPFILE"
+    cat "$ACPI_STATE_LOGFILE" > $TMPFILE
+    log_info "$LOGFILE" "ACPI Statistics since the beginning of the log (`$BIN_DATE -j -f %s $oldest_acpi_ts`):"
+    if ! log_stats $TMPFILE; then return 1; fi
+        
+    # Delete the temporary file
+    $BIN_RM -f "$TMPFILE"
 
-	return 0	
+    return 0    
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	run_main "$LOGFILE" "$SCRIPT_NAME"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    run_main "$LOGFILE" "$SCRIPT_NAME"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/acpiStats.sh
+++ b/acpiStats.sh
@@ -63,7 +63,7 @@ parseInputParams() {
     while getopts ":p:" opt; do
     
         case $opt in
-            p)    echo "$OPTARG" | grep -E "^$regex_pows$" >/dev/null
+            p) echo "$OPTARG" | grep -E "^$regex_pows$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_COMPUTE_CONSUMPTION="1"    
                     I_W_S0=`echo "$OPTARG" | cut -f1 -d,`            

--- a/acpiStats.sh
+++ b/acpiStats.sh
@@ -14,7 +14,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -42,9 +42,9 @@ readonly S_IN_YEAR=31536000
 
 # Initialisation of the default values for the arguments of the script
 I_COMPUTE_CONSUMPTION="0"
-I_W_S0="0"            # Power consumed by the NAS in S0 (in mW)
-I_W_S3="0"            # Power consumed by the NAS in S3 (in mW)
-I_W_S5="0"            # Power consumed by the NAS in S5 (in mW)
+I_W_S0="0"  # Power consumed by the NAS in S0 (in mW)
+I_W_S3="0"  # Power consumed by the NAS in S3 (in mW)
+I_W_S5="0"  # Power consumed by the NAS in S5 (in mW)
 
 
 ##################################
@@ -119,7 +119,7 @@ compute_stat() {
 
     current_line="1"
 
-    nbLinesInFile=`wc -l "$log_file" | awk ' { print $1 } '`    # find number of lines
+    nbLinesInFile=`wc -l "$log_file" | awk ' { print $1 } '`  # find number of lines
 
     # Itterate the file to compute the time spent by the NAS
     # in the state described by the pattern

--- a/acpiStats.sh
+++ b/acpiStats.sh
@@ -61,14 +61,14 @@ parseInputParams() {
 
     # parse the optional arguments
     while getopts ":p:" opt; do
-    
+
         case $opt in
             p) echo "$OPTARG" | grep -E "^$regex_pows$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
-                    I_COMPUTE_CONSUMPTION="1"    
-                    I_W_S0=`echo "$OPTARG" | cut -f1 -d,`            
-                    I_W_S3=`echo "$OPTARG" | cut -f2 -d,`            
-                    I_W_S5=`echo "$OPTARG" | cut -f3 -d,`            
+                    I_COMPUTE_CONSUMPTION="1"
+                    I_W_S0=`echo "$OPTARG" | cut -f1 -d,`
+                    I_W_S3=`echo "$OPTARG" | cut -f2 -d,`
+                    I_W_S5=`echo "$OPTARG" | cut -f3 -d,`
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -p. Should be \"pS0,pS3,pS5\", were pSx are integer"
                     return 1
@@ -84,14 +84,14 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "0" ]; then
         echo "No mandatory arguments should be provided"
         return 1
     fi
-    
+
         return 0
 }
 
@@ -113,12 +113,12 @@ compute_stat() {
     pattern="$2"
 
     date_format=`ts_format`
-    
+
     duration="0"
     duration_tot="0"
-    
+
     current_line="1"
-    
+
     nbLinesInFile=`wc -l "$log_file" | awk ' { print $1 } '`    # find number of lines
 
     # Itterate the file to compute the time spent by the NAS
@@ -127,14 +127,14 @@ compute_stat() {
     do
         old_ts="$current_ts"
         old_pattern="$current_pattern"
-    
+
         log_entry=`sed "$current_line"!d "$log_file"`
 
         # get line data from log file
-        current_date=`echo "$log_entry" | cut -f1`        
-        current_pattern=`echo "$log_entry" | cut -f3`        
+        current_date=`echo "$log_entry" | cut -f1`
+        current_pattern=`echo "$log_entry" | cut -f3`
         current_ts=`$BIN_DATE -j -f "$date_format" "$current_date" +%s`
-        
+
         # compute duration for pattern
         if [ "$current_line" -gt "1" ]; then
             deltat=$(($current_ts-$old_ts))
@@ -149,8 +149,8 @@ compute_stat() {
 
     # Take into account the time between the last
     # timestamp and now
-    old_ts="$current_ts"    
-    current_ts=`$BIN_DATE +%s`    
+    old_ts="$current_ts"
+    current_ts=`$BIN_DATE +%s`
     deltat=$(($current_ts-$old_ts))
     duration_tot=$(($duration_tot+$deltat))
     if [ "$current_pattern" = "$pattern" ]; then
@@ -179,7 +179,7 @@ log_stats() {
     S3p=`compute_stat "$file" "S3"`
     S5p=`compute_stat "$file" "S5"`
 
-    if [ "$I_COMPUTE_CONSUMPTION" -eq "1" ]; then         
+    if [ "$I_COMPUTE_CONSUMPTION" -eq "1" ]; then
         log_info "$LOGFILE" "S0 ($(($I_W_S0/1000)) W) (Working)       : $S0p percent"
         log_info "$LOGFILE" "S3 ($(($I_W_S3/1000)) W) (Suspend to RAM): $S3p percent"
         log_info "$LOGFILE" "S5 ($(($I_W_S5/1000)) W) (Soft off)      : $S5p percent"
@@ -192,7 +192,7 @@ log_stats() {
     fi
 
     # consistency check
-    percentage_tot=$(($S0p+$S3p+$S5p))    
+    percentage_tot=$(($S0p+$S3p+$S5p))
 
     if [ $percentage_tot -ge "98" -a $percentage_tot -le "102" ]; then
         return 0
@@ -216,7 +216,7 @@ main() {
         log_error "$LOGFILE" "Could not read \"$ACPI_STATE_LOGFILE\" that should contain the acpi states history"
         return 1
     fi
-    
+
     if [ $oldest_acpi_ts -le `$BIN_DATE -j -v -"$S_IN_WEEK"S +%s` ]; then
         get_log_entries "$ACPI_STATE_LOGFILE" "$S_IN_WEEK" > $TMPFILE
         log_info "$LOGFILE" "ACPI Statistics for the last week:"
@@ -238,11 +238,11 @@ main() {
     cat "$ACPI_STATE_LOGFILE" > $TMPFILE
     log_info "$LOGFILE" "ACPI Statistics since the beginning of the log (`$BIN_DATE -j -f %s $oldest_acpi_ts`):"
     if ! log_stats $TMPFILE; then return 1; fi
-        
+
     # Delete the temporary file
     $BIN_RM -f "$TMPFILE"
 
-    return 0    
+    return 0
 }
 
 

--- a/backupData.sh
+++ b/backupData.sh
@@ -128,7 +128,7 @@ parseInputParams() {
     # (there should be none)
     while getopts ":s:b:c:" opt; do
             case $opt in
-            s)    echo "$OPTARG" | grep -E "^(.+)@(.+)$" >/dev/null
+            s) echo "$OPTARG" | grep -E "^(.+)@(.+)$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_REMOTE_ACTIVE="1"
                     I_REMOTE_LOGIN=`echo "$OPTARG" | cut -f1 -d,`
@@ -155,14 +155,14 @@ parseInputParams() {
                     echo "Remote login data (\"$OPTARG\") does not have the expected format: username@hostname"
                     return 1
                 fi ;;
-            b)    echo "$OPTARG" | grep -E "^([0-9]+)$" >/dev/null
+            b) echo "$OPTARG" | grep -E "^([0-9]+)$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_ROLLBACK_S=$(($OPTARG*$S_IN_DAY))
                 else
                     echo "Wrong maximum rollback value, should be a positive integer or zero (unit: days) !"
                     return 1
                 fi ;;
-            c)    echo "$OPTARG" | grep -E "$regex_comp" >/dev/null
+            c) echo "$OPTARG" | grep -E "$regex_comp" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_COMPRESSION=$OPTARG
                 else

--- a/backupData.sh
+++ b/backupData.sh
@@ -97,7 +97,7 @@ run_fct_ssh() {
     cat "config.sh" > $TMP_FILE
     cat "common/commonSnapFcts.sh" >> $TMP_FILE
     echo "$@" >>  $TMP_FILE
-    
+
     # run the code on the remote host
     if [ -z "$I_PATH_KEY" ]; then
         $BIN_SSH -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
@@ -105,10 +105,10 @@ run_fct_ssh() {
         $BIN_SSH -i "$I_PATH_KEY" -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
     fi
     return_code="$?"
-    
+
     # delete the tmp file
     $BIN_RM $TMP_FILE
-    
+
     return $return_code
 }
 
@@ -121,9 +121,9 @@ run_fct_ssh() {
 ##################################
 parseInputParams() {
     local opt current_fs current_src_pool dest_pool regex_rollback host regex_comp comp_num fs_num
-    
+
     regex_comp="^($SUPPORTED_COMPRESSION)([,]($SUPPORTED_COMPRESSION)){0,}$"
-    
+
     # parse the optional parameters
     # (there should be none)
     while getopts ":s:b:c:" opt; do
@@ -133,16 +133,16 @@ parseInputParams() {
                     I_REMOTE_ACTIVE="1"
                     I_REMOTE_LOGIN=`echo "$OPTARG" | cut -f1 -d,`
                     I_PATH_KEY=`echo "$OPTARG" | cut -s -f2 -d,`    # empty if path not specified (i.e. no "," found)
-                    
+
                     # set variables to ensure remote execution of
                     # some parts of the script
                     RUN_FCT_SSH="run_fct_ssh"
                     if [ -z "$I_PATH_KEY" ]; then
                         RUN_CMD_SSH="$BIN_SSH -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"
-                    else                
-                        RUN_CMD_SSH="$BIN_SSH -i $I_PATH_KEY -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"                
+                    else
+                        RUN_CMD_SSH="$BIN_SSH -i $I_PATH_KEY -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"
                     fi
-                    
+
                     # testing ssh connection
                     if $RUN_CMD_SSH exit 0; then
                         echo "SSH connection test successful."
@@ -180,7 +180,7 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "2" ]; then
@@ -189,22 +189,22 @@ parseInputParams() {
     fi
 
     # Itterate through all source filesystems for which a backup should be done
-    # and check if the current fs exists    
+    # and check if the current fs exists
     I_SRC_FSS=`echo "$1" | sed 's/,/ /g'` # replace commas by space as for loops on new line and space
-    for current_fs in $I_SRC_FSS ; do    
+    for current_fs in $I_SRC_FSS ; do
         if ! $BIN_ZFS list $current_fs 2>/dev/null 1>/dev/null; then
             echo "source filesystem \"$current_fs\" does not exist."
             return 1
         fi
-    done    
-    
+    done
+
     # Check if the destination filesystem exists
     I_DEST_FS="$2"
     if ! $RUN_CMD_SSH $BIN_ZFS list $I_DEST_FS 2>/dev/null 1>/dev/null; then
         echo "destination filesystem \"$I_DEST_FS\" does not exist."
         return 1
     fi
-    
+
     # ensure that the ZPOOL of the destination filesystem is different from the
     # ZPOOL(s) of the source filesystems
     if [ "$I_REMOTE_ACTIVE" -eq "0" ]; then
@@ -217,16 +217,16 @@ parseInputParams() {
             fi
         done
     fi
-    
+
     # Ensure that the number of compression algorithm provided is compatible with
     # the number of source filesystems
     if [ -n "$I_COMPRESSION" ]; then
-        
+
         # number of compression algorithm defined
         comp_num=`echo "$I_COMPRESSION" | tr "," "\n" | wc -l`
         # number of source fs defined
         fs_num=`echo "$I_SRC_FSS" | tr " " "\n" | wc -l`
-        
+
         # if the number of compression algorithm defined is neither 1
         # nor equal to the number number of source fs that were defined
         if [ $comp_num -ne 1 -a $comp_num -ne $fs_num ]; then
@@ -234,7 +234,7 @@ parseInputParams() {
             return 1
         fi
     fi
-    
+
     return 0
 }
 
@@ -249,12 +249,12 @@ ensureRemoteFSExists() {
     local fs pool readonly_mode
     fs="$1"
     pool=`echo "$fs" | cut -f1 -d/`
-    
+
     # Check if the fs already exists
     if $RUN_CMD_SSH $BIN_ZFS list $fs 2>/dev/null 1>/dev/null; then
         return 0
     fi
-    
+
     log_info "$LOGFILE" "Destination filesystem \"$fs\" DOES NOT exist yet. Creating it..."
 
     # Ensures that the destination pool is NOT readonly
@@ -312,7 +312,7 @@ backup() {
     dest_fs="$2"
 
     logPrefix="Backup of \"$src_fs\""
-    
+
     # Get the newest snapshot on dest fs
     newestSnapDestFs=`$RUN_FCT_SSH sortSnapshots "$dest_fs" "" | head -n 1`
     # Get the oldest snapshot on the src fs
@@ -363,7 +363,7 @@ backup() {
 
             # Compute the required rollback duration
             snapSrcFsTimestamp1970=`getSnapTimestamp1970 "$snapSrcFs"`
-            newestSnapDestFsCreation1970=`$RUN_FCT_SSH getSnapTimestamp1970 "$newestSnapDestFs"`        
+            newestSnapDestFsCreation1970=`$RUN_FCT_SSH getSnapTimestamp1970 "$newestSnapDestFs"`
             snapsAgeDiff=$(($newestSnapDestFsCreation1970-$snapSrcFsTimestamp1970))
             if [ $snapsAgeDiff -gt $I_MAX_ROLLBACK_S ]; then
                 log_warning "$LOGFILE" "$logPrefix: A rollback of \"$(($snapsAgeDiff/$S_IN_DAY))\" days would be required to perform the incremental backup !"
@@ -398,7 +398,7 @@ main() {
     local returnCode current_fs currentSubSrcFs currentSubDstFs algo cpt
 
     returnCode=0
-    
+
     log_info "$LOGFILE" "Starting backup of \"$I_SRC_FSS\""
 
     # Itterate through all source filesystems for which a backup should be done
@@ -406,12 +406,12 @@ main() {
     for current_fs in $I_SRC_FSS ; do
 
         cpt=$(($cpt+1))
-    
+
         # for the current fs and all its sub-filesystems
         for currentSubSrcFs in `$BIN_ZFS list -t filesystem,volume -r -H -o name $current_fs`; do
 
             currentSubDstFs="$I_DEST_FS/$currentSubSrcFs"
-        
+
             # create the dest filesystems (recursively)
             # if they do not yet exist and exit if it fails
             if ! ensureRemoteFSExists "$currentSubDstFs"; then

--- a/backupData.sh
+++ b/backupData.sh
@@ -46,7 +46,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -64,17 +64,17 @@ readonly SUPPORTED_COMPRESSION='on|off|lzjb|gzip|gzip-[1-9]|zle|lz4'
 readonly LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.log"
 readonly TMP_FILE="$CFG_TMP_FOLDER/run_fct_ssh.sh"
 readonly TMPFILE_ARGS="$CFG_TMP_FOLDER/$SCRIPT_NAME.$$.args.tmp"
-readonly S_IN_DAY=86400            # Number of seconds in a day
-readonly SSH_BATCHMODE="yes"        # Only public key authentication is allowed in batch mode
+readonly S_IN_DAY=86400  # Number of seconds in a day
+readonly SSH_BATCHMODE="yes"  # Only public key authentication is allowed in batch mode
                     # (should only change to "no" for test purposes)
 
 # Initialization of inputs corresponding to optional args of the script
-I_REMOTE_ACTIVE="0"            # By default the destination filesystem is local
-RUN_FCT_SSH=""                # This should be put in front of FUNCTIONS that may have to be executed remotely
-                    # By default (i.e. local backup) "RUN_FCT_SSH" does not have any effect
-RUN_CMD_SSH=""                # This should be put in front of COMMANDS that may have to be executed remotely
-                    # By default (i.e. local backup) "RUN_CMD_SSH" does not have any effect
-I_MAX_ROLLBACK_S=$((10*$S_IN_DAY))    # Default value of max rollback
+I_REMOTE_ACTIVE="0"  # By default the destination filesystem is local
+RUN_FCT_SSH=""  # This should be put in front of FUNCTIONS that may have to be executed remotely
+                # By default (i.e. local backup) "RUN_FCT_SSH" does not have any effect
+RUN_CMD_SSH=""  # This should be put in front of COMMANDS that may have to be executed remotely
+                # By default (i.e. local backup) "RUN_CMD_SSH" does not have any effect
+I_MAX_ROLLBACK_S=$((10*$S_IN_DAY))  # Default value of max rollback
 
 # Set variables corresponding to the input parameters
 ARGUMENTS="$@"
@@ -132,7 +132,7 @@ parseInputParams() {
                 if [ "$?" -eq "0" ] ; then
                     I_REMOTE_ACTIVE="1"
                     I_REMOTE_LOGIN=`echo "$OPTARG" | cut -f1 -d,`
-                    I_PATH_KEY=`echo "$OPTARG" | cut -s -f2 -d,`    # empty if path not specified (i.e. no "," found)
+                    I_PATH_KEY=`echo "$OPTARG" | cut -s -f2 -d,`  # empty if path not specified (i.e. no "," found)
 
                     # set variables to ensure remote execution of
                     # some parts of the script

--- a/backupData.sh
+++ b/backupData.sh
@@ -8,45 +8,45 @@
 #
 # Usage: backupData.sh [-s user@host[,path2privatekey]] [-b maxRollbck] [-c compression[,...]] fsSource[,...] fsDest
 #
-#	-s user@host[,path2privatekey]:	Specify a remote host on which the destination filesystem
-#			is located
-#			Prerequisite: An ssh server shall be running on the host and
-#			public key authentication shall be available
-#			(By default the destination filesystem is on the local host)
-#			host: ip address or name of the host computer
-#			user: name of the user on the host computer
-#			path2privatekey: The path to the private key that should be used to
-#				login. (This is required either if you are logged under another user
-#				in the local host, or if you run the script from cron)
-#	-b maxRollbck :	Biggest allowed rollback (in days) on the destination fs.
-#			A rollback is necessary if the snapshots available on the
-#			destination fs are not available anymore on the source fs
-#			Default value: 10 days
-#	-c compression[,...] : compression algorithm to be used for the respective
-#			destination filesystem.
-#			If only one compression algorithm is provided, this algorithm applies to each
-#			destination filesystem.
-#			If more then one compression algorithm is provided (exactly the same number
-#			of algorithm shall be provided as the number of source filesystems),
-#			compressionN is the algorithm that will be set for the destination filesystem
-#			corresponding to fsSourceN.
-#	fsSource[,...] :  zfs filesystems to be backed-up (source).
-#	   		Several file systems can be provided (They shall be separated by a comma ",")
-#	   		Note: These fs (as well as the sub-fs) shall have a default mountpoint
-# 	fsDest : 	zfs filesystem in which the data should be backed-up (destination)
-#			Note: This filesystem must already exist before to launch the backup.
-#			Note: The ZPOOL in which this filesystem is located should be different
-#			      from the ZPOOL(s) of the source filesystems
+#    -s user@host[,path2privatekey]: Specify a remote host on which the destination filesystem
+#            is located
+#            Prerequisite: An ssh server shall be running on the host and
+#            public key authentication shall be available
+#            (By default the destination filesystem is on the local host)
+#            host: ip address or name of the host computer
+#            user: name of the user on the host computer
+#            path2privatekey: The path to the private key that should be used to
+#                login. (This is required either if you are logged under another user
+#                in the local host, or if you run the script from cron)
+#    -b maxRollbck : Biggest allowed rollback (in days) on the destination fs.
+#            A rollback is necessary if the snapshots available on the
+#            destination fs are not available anymore on the source fs
+#            Default value: 10 days
+#    -c compression[,...] : compression algorithm to be used for the respective
+#            destination filesystem.
+#            If only one compression algorithm is provided, this algorithm applies to each
+#            destination filesystem.
+#            If more then one compression algorithm is provided (exactly the same number
+#            of algorithm shall be provided as the number of source filesystems),
+#            compressionN is the algorithm that will be set for the destination filesystem
+#            corresponding to fsSourceN.
+#    fsSource[,...] : zfs filesystems to be backed-up (source).
+#            Several file systems can be provided (They shall be separated by a comma ",")
+#            Note: These fs (as well as the sub-fs) shall have a default mountpoint
+#    fsDest : zfs filesystem in which the data should be backed-up (destination)
+#            Note: This filesystem must already exist before to launch the backup.
+#            Note: The ZPOOL in which this filesystem is located should be different
+#                  from the ZPOOL(s) of the source filesystems
 #
 # Example:
-#	"backupData.sh tank/nas_scripts tank_backup" will create a backup of the ZFS fs
-#	"tank/nas_scripts" (and of all its sub-filesystems) in the ZFS fs "tank_backup".
-#	I.e. After the backup (at least) an fs "tank_backup/tank/nas_scripts" will exist.
+#    "backupData.sh tank/nas_scripts tank_backup" will create a backup of the ZFS fs
+#    "tank/nas_scripts" (and of all its sub-filesystems) in the ZFS fs "tank_backup".
+#    I.e. After the backup (at least) an fs "tank_backup/tank/nas_scripts" will exist.
 #
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -64,17 +64,17 @@ readonly SUPPORTED_COMPRESSION='on|off|lzjb|gzip|gzip-[1-9]|zle|lz4'
 readonly LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.log"
 readonly TMP_FILE="$CFG_TMP_FOLDER/run_fct_ssh.sh"
 readonly TMPFILE_ARGS="$CFG_TMP_FOLDER/$SCRIPT_NAME.$$.args.tmp"
-readonly S_IN_DAY=86400			# Number of seconds in a day
-readonly SSH_BATCHMODE="yes"		# Only public key authentication is allowed in batch mode
-					# (should only change to "no" for test purposes)
+readonly S_IN_DAY=86400            # Number of seconds in a day
+readonly SSH_BATCHMODE="yes"        # Only public key authentication is allowed in batch mode
+                    # (should only change to "no" for test purposes)
 
 # Initialization of inputs corresponding to optional args of the script
-I_REMOTE_ACTIVE="0"			# By default the destination filesystem is local
-RUN_FCT_SSH=""				# This should be put in front of FUNCTIONS that may have to be executed remotely
-					# By default (i.e. local backup) "RUN_FCT_SSH" does not have any effect
-RUN_CMD_SSH=""				# This should be put in front of COMMANDS that may have to be executed remotely
-					# By default (i.e. local backup) "RUN_CMD_SSH" does not have any effect
-I_MAX_ROLLBACK_S=$((10*$S_IN_DAY))	# Default value of max rollback
+I_REMOTE_ACTIVE="0"            # By default the destination filesystem is local
+RUN_FCT_SSH=""                # This should be put in front of FUNCTIONS that may have to be executed remotely
+                    # By default (i.e. local backup) "RUN_FCT_SSH" does not have any effect
+RUN_CMD_SSH=""                # This should be put in front of COMMANDS that may have to be executed remotely
+                    # By default (i.e. local backup) "RUN_CMD_SSH" does not have any effect
+I_MAX_ROLLBACK_S=$((10*$S_IN_DAY))    # Default value of max rollback
 
 # Set variables corresponding to the input parameters
 ARGUMENTS="$@"
@@ -91,25 +91,25 @@ ARGUMENTS="$@"
 # Run local functions remotely
 ##########################
 run_fct_ssh() {
-	local return_code
+    local return_code
 
-	# generating the tmp file containing the code to be executed
-	cat "config.sh" > $TMP_FILE
-	cat "common/commonSnapFcts.sh" >> $TMP_FILE
-	echo "$@" >>  $TMP_FILE
-	
-	# run the code on the remote host
-	if [ -z "$I_PATH_KEY" ]; then
-		$BIN_SSH -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
-	else
-		$BIN_SSH -i "$I_PATH_KEY" -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
-	fi
-	return_code="$?"
-	
-	# delete the tmp file
-	$BIN_RM $TMP_FILE
-	
-	return $return_code
+    # generating the tmp file containing the code to be executed
+    cat "config.sh" > $TMP_FILE
+    cat "common/commonSnapFcts.sh" >> $TMP_FILE
+    echo "$@" >>  $TMP_FILE
+    
+    # run the code on the remote host
+    if [ -z "$I_PATH_KEY" ]; then
+        $BIN_SSH -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
+    else
+        $BIN_SSH -i "$I_PATH_KEY" -oBatchMode=$SSH_BATCHMODE -t $I_REMOTE_LOGIN "/bin/sh" < $TMP_FILE
+    fi
+    return_code="$?"
+    
+    # delete the tmp file
+    $BIN_RM $TMP_FILE
+    
+    return $return_code
 }
 
 
@@ -120,176 +120,176 @@ run_fct_ssh() {
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local opt current_fs current_src_pool dest_pool regex_rollback host regex_comp comp_num fs_num
-	
-	regex_comp="^($SUPPORTED_COMPRESSION)([,]($SUPPORTED_COMPRESSION)){0,}$"
-	
-	# parse the optional parameters
-	# (there should be none)
-	while getopts ":s:b:c:" opt; do
-        	case $opt in
-			s)	echo "$OPTARG" | grep -E "^(.+)@(.+)$" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_REMOTE_ACTIVE="1"
-					I_REMOTE_LOGIN=`echo "$OPTARG" | cut -f1 -d,`
-					I_PATH_KEY=`echo "$OPTARG" | cut -s -f2 -d,`	# empty if path not specified (i.e. no "," found)
-					
-					# set variables to ensure remote execution of
-					# some parts of the script
-					RUN_FCT_SSH="run_fct_ssh"
-					if [ -z "$I_PATH_KEY" ]; then
-						RUN_CMD_SSH="$BIN_SSH -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"
-					else				
-						RUN_CMD_SSH="$BIN_SSH -i $I_PATH_KEY -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"				
-					fi
-					
-					# testing ssh connection
-					if $RUN_CMD_SSH exit 0; then
-						echo "SSH connection test successful."
-					else
-						echo "SSH connection failed. Please check username / hostname,"
-						echo "ensure that public key authentication is configured, and that you have access to the private key file"
-						return 1
-					fi
-				else
-					echo "Remote login data (\"$OPTARG\") does not have the expected format: username@hostname"
-					return 1
-				fi ;;
-			b)	echo "$OPTARG" | grep -E "^([0-9]+)$" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_MAX_ROLLBACK_S=$(($OPTARG*$S_IN_DAY))
-				else
-					echo "Wrong maximum rollback value, should be a positive integer or zero (unit: days) !"
-					return 1
-				fi ;;
-			c)	echo "$OPTARG" | grep -E "$regex_comp" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_COMPRESSION=$OPTARG
-				else
-					echo "Bad compression definition, should be a set of compression algorithms (supported by ZFS) separated by comma \",\" characters"
-					return 1
-				fi ;;
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
+    local opt current_fs current_src_pool dest_pool regex_rollback host regex_comp comp_num fs_num
+    
+    regex_comp="^($SUPPORTED_COMPRESSION)([,]($SUPPORTED_COMPRESSION)){0,}$"
+    
+    # parse the optional parameters
+    # (there should be none)
+    while getopts ":s:b:c:" opt; do
+            case $opt in
+            s)    echo "$OPTARG" | grep -E "^(.+)@(.+)$" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_REMOTE_ACTIVE="1"
+                    I_REMOTE_LOGIN=`echo "$OPTARG" | cut -f1 -d,`
+                    I_PATH_KEY=`echo "$OPTARG" | cut -s -f2 -d,`    # empty if path not specified (i.e. no "," found)
+                    
+                    # set variables to ensure remote execution of
+                    # some parts of the script
+                    RUN_FCT_SSH="run_fct_ssh"
+                    if [ -z "$I_PATH_KEY" ]; then
+                        RUN_CMD_SSH="$BIN_SSH -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"
+                    else                
+                        RUN_CMD_SSH="$BIN_SSH -i $I_PATH_KEY -oBatchMode=$SSH_BATCHMODE $I_REMOTE_LOGIN"                
+                    fi
+                    
+                    # testing ssh connection
+                    if $RUN_CMD_SSH exit 0; then
+                        echo "SSH connection test successful."
+                    else
+                        echo "SSH connection failed. Please check username / hostname,"
+                        echo "ensure that public key authentication is configured, and that you have access to the private key file"
+                        return 1
+                    fi
+                else
+                    echo "Remote login data (\"$OPTARG\") does not have the expected format: username@hostname"
+                    return 1
+                fi ;;
+            b)    echo "$OPTARG" | grep -E "^([0-9]+)$" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_MAX_ROLLBACK_S=$(($OPTARG*$S_IN_DAY))
+                else
+                    echo "Wrong maximum rollback value, should be a positive integer or zero (unit: days) !"
+                    return 1
+                fi ;;
+            c)    echo "$OPTARG" | grep -E "$regex_comp" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_COMPRESSION=$OPTARG
+                else
+                    echo "Bad compression definition, should be a set of compression algorithms (supported by ZFS) separated by comma \",\" characters"
+                    return 1
+                fi ;;
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
                         :)
-				echo "Option -$OPTARG requires an argument"
-				return 1 ;;
-        	esac
-	done
+                echo "Option -$OPTARG requires an argument"
+                return 1 ;;
+            esac
+    done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "2" ]; then
-		echo "Exactly 2 mandatory argument shall be provided"
-		return 1
-	fi
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "2" ]; then
+        echo "Exactly 2 mandatory argument shall be provided"
+        return 1
+    fi
 
-	# Itterate through all source filesystems for which a backup should be done
-	# and check if the current fs exists	
-	I_SRC_FSS=`echo "$1" | sed 's/,/ /g'` # replace commas by space as for loops on new line and space
-	for current_fs in $I_SRC_FSS ; do	
-		if ! $BIN_ZFS list $current_fs 2>/dev/null 1>/dev/null; then
-			echo "source filesystem \"$current_fs\" does not exist."
-			return 1
-		fi
-	done	
-	
-	# Check if the destination filesystem exists
-	I_DEST_FS="$2"
-	if ! $RUN_CMD_SSH $BIN_ZFS list $I_DEST_FS 2>/dev/null 1>/dev/null; then
-		echo "destination filesystem \"$I_DEST_FS\" does not exist."
-		return 1
-	fi
-	
-	# ensure that the ZPOOL of the destination filesystem is different from the
-	# ZPOOL(s) of the source filesystems
-	if [ "$I_REMOTE_ACTIVE" -eq "0" ]; then
-		dest_pool=`echo "$I_DEST_FS" | cut -f1 -d/`
-		for current_fs in $I_SRC_FSS ; do
-			current_src_pool=`echo "$current_fs" | cut -f1 -d/`
-			if [ "$dest_pool" = "$current_src_pool" ]; then
-				echo "The source filesystem \"$current_fs\" is in the same pool than the destination filesystem \"$I_DEST_FS\""
-				return 1
-			fi
-		done
-	fi
-	
-	# Ensure that the number of compression algorithm provided is compatible with
-	# the number of source filesystems
-	if [ -n "$I_COMPRESSION" ]; then
-		
-		# number of compression algorithm defined
-		comp_num=`echo "$I_COMPRESSION" | tr "," "\n" | wc -l`
-		# number of source fs defined
-		fs_num=`echo "$I_SRC_FSS" | tr " " "\n" | wc -l`
-		
-		# if the number of compression algorithm defined is neither 1
-		# nor equal to the number number of source fs that were defined
-		if [ $comp_num -ne 1 -a $comp_num -ne $fs_num ]; then
-			echo "Bad compression definition, the number of compression algorithm should either equal 1 or should be equal to the number of source filesystems"
-			return 1
-		fi
-	fi
-	
-	return 0
+    # Itterate through all source filesystems for which a backup should be done
+    # and check if the current fs exists    
+    I_SRC_FSS=`echo "$1" | sed 's/,/ /g'` # replace commas by space as for loops on new line and space
+    for current_fs in $I_SRC_FSS ; do    
+        if ! $BIN_ZFS list $current_fs 2>/dev/null 1>/dev/null; then
+            echo "source filesystem \"$current_fs\" does not exist."
+            return 1
+        fi
+    done    
+    
+    # Check if the destination filesystem exists
+    I_DEST_FS="$2"
+    if ! $RUN_CMD_SSH $BIN_ZFS list $I_DEST_FS 2>/dev/null 1>/dev/null; then
+        echo "destination filesystem \"$I_DEST_FS\" does not exist."
+        return 1
+    fi
+    
+    # ensure that the ZPOOL of the destination filesystem is different from the
+    # ZPOOL(s) of the source filesystems
+    if [ "$I_REMOTE_ACTIVE" -eq "0" ]; then
+        dest_pool=`echo "$I_DEST_FS" | cut -f1 -d/`
+        for current_fs in $I_SRC_FSS ; do
+            current_src_pool=`echo "$current_fs" | cut -f1 -d/`
+            if [ "$dest_pool" = "$current_src_pool" ]; then
+                echo "The source filesystem \"$current_fs\" is in the same pool than the destination filesystem \"$I_DEST_FS\""
+                return 1
+            fi
+        done
+    fi
+    
+    # Ensure that the number of compression algorithm provided is compatible with
+    # the number of source filesystems
+    if [ -n "$I_COMPRESSION" ]; then
+        
+        # number of compression algorithm defined
+        comp_num=`echo "$I_COMPRESSION" | tr "," "\n" | wc -l`
+        # number of source fs defined
+        fs_num=`echo "$I_SRC_FSS" | tr " " "\n" | wc -l`
+        
+        # if the number of compression algorithm defined is neither 1
+        # nor equal to the number number of source fs that were defined
+        if [ $comp_num -ne 1 -a $comp_num -ne $fs_num ]; then
+            echo "Bad compression definition, the number of compression algorithm should either equal 1 or should be equal to the number of source filesystems"
+            return 1
+        fi
+    fi
+    
+    return 0
 }
 
 ##################################
 # Ensures the availability of the filesystem given as parameter
 # Param 1: filesystem name
 # Return : 0 if the filesystem is existing or could be created,
-#	   1 otherwise
+#       1 otherwise
 ##################################
 ensureRemoteFSExists() {
 
-	local fs pool readonly_mode
-	fs="$1"
-	pool=`echo "$fs" | cut -f1 -d/`
-	
-	# Check if the fs already exists
-	if $RUN_CMD_SSH $BIN_ZFS list $fs 2>/dev/null 1>/dev/null; then
-		return 0
-	fi
-	
-	log_info "$LOGFILE" "Destination filesystem \"$fs\" DOES NOT exist yet. Creating it..."
+    local fs pool readonly_mode
+    fs="$1"
+    pool=`echo "$fs" | cut -f1 -d/`
+    
+    # Check if the fs already exists
+    if $RUN_CMD_SSH $BIN_ZFS list $fs 2>/dev/null 1>/dev/null; then
+        return 0
+    fi
+    
+    log_info "$LOGFILE" "Destination filesystem \"$fs\" DOES NOT exist yet. Creating it..."
 
-	# Ensures that the destination pool is NOT readonly
-	# So that the filesystems can be created if required
-	readonly_mode=`$RUN_CMD_SSH $BIN_ZFS get -H readonly $pool | cut -f3`
-	[ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=off $pool >/dev/null; then
-		log_error "$LOGFILE" "Destination pool could not be set to READONLY=off. Filesystem creation not possible "
-		return 1
-	fi
+    # Ensures that the destination pool is NOT readonly
+    # So that the filesystems can be created if required
+    readonly_mode=`$RUN_CMD_SSH $BIN_ZFS get -H readonly $pool | cut -f3`
+    [ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=off $pool >/dev/null; then
+        log_error "$LOGFILE" "Destination pool could not be set to READONLY=off. Filesystem creation not possible "
+        return 1
+    fi
 
-	# create the filesystem (-p option to create the parent fs if it does not exist)
-	if ! $RUN_CMD_SSH $BIN_ZFS create -p "$fs"; then
-		log_error "$LOGFILE" "The filesystem could NOT be created"
+    # create the filesystem (-p option to create the parent fs if it does not exist)
+    if ! $RUN_CMD_SSH $BIN_ZFS create -p "$fs"; then
+        log_error "$LOGFILE" "The filesystem could NOT be created"
 
-		# Set the destination pool to readonly
-		[ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $pool >/dev/null; then
-			log_error "$LOGFILE" "The destination pool could not be set to \"readonly=on\""
-		fi
+        # Set the destination pool to readonly
+        [ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $pool >/dev/null; then
+            log_error "$LOGFILE" "The destination pool could not be set to \"readonly=on\""
+        fi
 
-		return 1
-	else
-		log_info "$LOGFILE" "Filesystem created successfully"
+        return 1
+    else
+        log_info "$LOGFILE" "Filesystem created successfully"
 
-		# Set the destination filesystem to readonly
-		if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $fs >/dev/null; then
-			log_error "$LOGFILE" "The destination filesystem could not be set to \"readonly=on\""
-		fi
+        # Set the destination filesystem to readonly
+        if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $fs >/dev/null; then
+            log_error "$LOGFILE" "The destination filesystem could not be set to \"readonly=on\""
+        fi
 
-		# Set the destination pool to readonly
-		[ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $pool >/dev/null; then
-			log_warning "$LOGFILE" "The destination pool could not be set to \"readonly=on\""
-		fi
+        # Set the destination pool to readonly
+        [ "$readonly_mode" = "on" ] && if ! $RUN_CMD_SSH $BIN_ZFS set readonly=on $pool >/dev/null; then
+            log_warning "$LOGFILE" "The destination pool could not be set to \"readonly=on\""
+        fi
 
-		return 0
-	fi
+        return 0
+    fi
 }
 
 
@@ -300,162 +300,162 @@ ensureRemoteFSExists() {
 # Param 1: source filesystem
 # Param 2: destination filesystem
 # Return : 0 if the backup could be performed successfully or
-#	     if there is nothing to backup
-#	   1 if the backup failed
+#         if there is nothing to backup
+#       1 if the backup failed
 ##################################
 backup() {
-	local src_fs dest_fs logPrefix newestSnapDestFs oldestSnapSrcFs newestSnapSrcFs snapDestFs \
-		removeDestFSInName snapSrcFs snapSrcFsTimestamp1970 newestSnapDestFsCreation1970 \
-		snapsAgeDiff
+    local src_fs dest_fs logPrefix newestSnapDestFs oldestSnapSrcFs newestSnapSrcFs snapDestFs \
+        removeDestFSInName snapSrcFs snapSrcFsTimestamp1970 newestSnapDestFsCreation1970 \
+        snapsAgeDiff
 
-	src_fs="$1"
-	dest_fs="$2"
+    src_fs="$1"
+    dest_fs="$2"
 
-	logPrefix="Backup of \"$src_fs\""
-	
-	# Get the newest snapshot on dest fs
-	newestSnapDestFs=`$RUN_FCT_SSH sortSnapshots "$dest_fs" "" | head -n 1`
-	# Get the oldest snapshot on the src fs
-	oldestSnapSrcFs=`sortSnapshots "$src_fs" "" | tail -n -1`
-	# Get the newest snapshot on the src fs
-	newestSnapSrcFs=`sortSnapshots "$src_fs" "" | head -n 1`
+    logPrefix="Backup of \"$src_fs\""
+    
+    # Get the newest snapshot on dest fs
+    newestSnapDestFs=`$RUN_FCT_SSH sortSnapshots "$dest_fs" "" | head -n 1`
+    # Get the oldest snapshot on the src fs
+    oldestSnapSrcFs=`sortSnapshots "$src_fs" "" | tail -n -1`
+    # Get the newest snapshot on the src fs
+    newestSnapSrcFs=`sortSnapshots "$src_fs" "" | head -n 1`
 
-	# If there is no snapshot on dest fs, backup the oldest snapshot on the src fs
-	if [ -z "$newestSnapDestFs" ]; then
-		log_info "$LOGFILE" "$logPrefix: No snapfound found in destination filesystem"
+    # If there is no snapshot on dest fs, backup the oldest snapshot on the src fs
+    if [ -z "$newestSnapDestFs" ]; then
+        log_info "$LOGFILE" "$logPrefix: No snapfound found in destination filesystem"
 
-		if [ -z "$oldestSnapSrcFs" ]; then
-			log_info "$LOGFILE" "$logPrefix: No snapshot to be backed up found in source filesystem"
-			return 0
-		else
-			log_info "$LOGFILE" "$logPrefix: Backup up oldest snapshot \"$oldestSnapSrcFs\""
-			if ! $BIN_ZFS send $oldestSnapSrcFs | $RUN_CMD_SSH $BIN_ZFS receive -F $dest_fs >/dev/null; then
-				log_error "$LOGFILE" "$logPrefix: Backup failed"
-				return 1
-			else
-				log_info "$LOGFILE" "$logPrefix: Backup performed"
-			fi
-		fi
-	else
-		log_info "$LOGFILE" "$logPrefix: Last snapshot available in destination filesystem was \"$newestSnapDestFs\" before backup"
-	fi
+        if [ -z "$oldestSnapSrcFs" ]; then
+            log_info "$LOGFILE" "$logPrefix: No snapshot to be backed up found in source filesystem"
+            return 0
+        else
+            log_info "$LOGFILE" "$logPrefix: Backup up oldest snapshot \"$oldestSnapSrcFs\""
+            if ! $BIN_ZFS send $oldestSnapSrcFs | $RUN_CMD_SSH $BIN_ZFS receive -F $dest_fs >/dev/null; then
+                log_error "$LOGFILE" "$logPrefix: Backup failed"
+                return 1
+            else
+                log_info "$LOGFILE" "$logPrefix: Backup performed"
+            fi
+        fi
+    else
+        log_info "$LOGFILE" "$logPrefix: Last snapshot available in destination filesystem was \"$newestSnapDestFs\" before backup"
+    fi
 
-	# Get the newest snapshot on the dest fs
-	# (It may have changed, if a backup was performed above)
-	newestSnapDestFs=`$RUN_FCT_SSH sortSnapshots $dest_fs "" | head -n 1`
+    # Get the newest snapshot on the dest fs
+    # (It may have changed, if a backup was performed above)
+    newestSnapDestFs=`$RUN_FCT_SSH sortSnapshots $dest_fs "" | head -n 1`
 
-	# find the newest snapshot on the dest fs that is still
-	# available in the src fs and then perform an incremental
-	# backup starting from the latter snapshot
-	for snapDestFs in `$RUN_FCT_SSH sortSnapshots "$dest_fs" ""`; do
+    # find the newest snapshot on the dest fs that is still
+    # available in the src fs and then perform an incremental
+    # backup starting from the latter snapshot
+    for snapDestFs in `$RUN_FCT_SSH sortSnapshots "$dest_fs" ""`; do
 
-		# Compute the src fs snapshot name corresponding to the current dest fs snapshot
-		removeDestFSInName="s!$I_DEST_FS/!!g"
-		snapSrcFs=`echo "$snapDestFs" | sed -e "$removeDestFSInName"`
+        # Compute the src fs snapshot name corresponding to the current dest fs snapshot
+        removeDestFSInName="s!$I_DEST_FS/!!g"
+        snapSrcFs=`echo "$snapDestFs" | sed -e "$removeDestFSInName"`
 
-		if [ $snapSrcFs = $newestSnapSrcFs ]; then
-			log_info "$LOGFILE" "$logPrefix: No newer snapshot exist in source filesystem. Nothing to backup"
-			return 0
-		fi
+        if [ $snapSrcFs = $newestSnapSrcFs ]; then
+            log_info "$LOGFILE" "$logPrefix: No newer snapshot exist in source filesystem. Nothing to backup"
+            return 0
+        fi
 
-		# If the snapshot exists on the src fs
-		if $BIN_ZFS list -o name -t snapshot "$snapSrcFs" 2>/dev/null 1>/dev/null; then
+        # If the snapshot exists on the src fs
+        if $BIN_ZFS list -o name -t snapshot "$snapSrcFs" 2>/dev/null 1>/dev/null; then
 
-			# Compute the required rollback duration
-			snapSrcFsTimestamp1970=`getSnapTimestamp1970 "$snapSrcFs"`
-			newestSnapDestFsCreation1970=`$RUN_FCT_SSH getSnapTimestamp1970 "$newestSnapDestFs"`		
-			snapsAgeDiff=$(($newestSnapDestFsCreation1970-$snapSrcFsTimestamp1970))
-			if [ $snapsAgeDiff -gt $I_MAX_ROLLBACK_S ]; then
-				log_warning "$LOGFILE" "$logPrefix: A rollback of \"$(($snapsAgeDiff/$S_IN_DAY))\" days would be required to perform the incremental backup !"
-				log_warning "$LOGFILE" "$logPrefix: Current maximum allowed rollback value equals \"$(($I_MAX_ROLLBACK_S/$S_IN_DAY))\" days."
-				log_warning "$LOGFILE" "$logPrefix: Please increase the maximum allowed rollback duration to make the backup possible"
-				log_warning "$LOGFILE" "$logPrefix: Skipping backup of this filesystem"
-				return 1
-			fi
+            # Compute the required rollback duration
+            snapSrcFsTimestamp1970=`getSnapTimestamp1970 "$snapSrcFs"`
+            newestSnapDestFsCreation1970=`$RUN_FCT_SSH getSnapTimestamp1970 "$newestSnapDestFs"`        
+            snapsAgeDiff=$(($newestSnapDestFsCreation1970-$snapSrcFsTimestamp1970))
+            if [ $snapsAgeDiff -gt $I_MAX_ROLLBACK_S ]; then
+                log_warning "$LOGFILE" "$logPrefix: A rollback of \"$(($snapsAgeDiff/$S_IN_DAY))\" days would be required to perform the incremental backup !"
+                log_warning "$LOGFILE" "$logPrefix: Current maximum allowed rollback value equals \"$(($I_MAX_ROLLBACK_S/$S_IN_DAY))\" days."
+                log_warning "$LOGFILE" "$logPrefix: Please increase the maximum allowed rollback duration to make the backup possible"
+                log_warning "$LOGFILE" "$logPrefix: Skipping backup of this filesystem"
+                return 1
+            fi
 
-			log_info "$LOGFILE" "$logPrefix: Rolling back to last snapshot available on both source & destination fs: \"$snapDestFs\"..."
-			if ! $RUN_CMD_SSH $BIN_ZFS rollback -r $snapDestFs >/dev/null; then
-				log_error "$LOGFILE" "$logPrefix: Rollback failed"
-				return 1
-			fi
+            log_info "$LOGFILE" "$logPrefix: Rolling back to last snapshot available on both source & destination fs: \"$snapDestFs\"..."
+            if ! $RUN_CMD_SSH $BIN_ZFS rollback -r $snapDestFs >/dev/null; then
+                log_error "$LOGFILE" "$logPrefix: Rollback failed"
+                return 1
+            fi
 
-			log_info "$LOGFILE" "$logPrefix: Backing up incrementally from snapshot \"$snapSrcFs\" to \"$newestSnapSrcFs\" ..."
-			if ! $BIN_ZFS send -I "$snapSrcFs" "$newestSnapSrcFs" | $RUN_CMD_SSH $BIN_ZFS receive "$dest_fs" >/dev/null; then
-				log_error "$LOGFILE" "$logPrefix: Backup failed"
-				return 1
-			else
-				log_info "$LOGFILE" "$logPrefix: Backup performed"
-				return 0
-			fi
-		fi
-	done
+            log_info "$LOGFILE" "$logPrefix: Backing up incrementally from snapshot \"$snapSrcFs\" to \"$newestSnapSrcFs\" ..."
+            if ! $BIN_ZFS send -I "$snapSrcFs" "$newestSnapSrcFs" | $RUN_CMD_SSH $BIN_ZFS receive "$dest_fs" >/dev/null; then
+                log_error "$LOGFILE" "$logPrefix: Backup failed"
+                return 1
+            else
+                log_info "$LOGFILE" "$logPrefix: Backup performed"
+                return 0
+            fi
+        fi
+    done
 }
 
 ##################################
 # Main
 ##################################
 main() {
-	local returnCode current_fs currentSubSrcFs currentSubDstFs algo cpt
+    local returnCode current_fs currentSubSrcFs currentSubDstFs algo cpt
 
-	returnCode=0
-	
-	log_info "$LOGFILE" "Starting backup of \"$I_SRC_FSS\""
+    returnCode=0
+    
+    log_info "$LOGFILE" "Starting backup of \"$I_SRC_FSS\""
 
-	# Itterate through all source filesystems for which a backup should be done
-	cpt=0
-	for current_fs in $I_SRC_FSS ; do
+    # Itterate through all source filesystems for which a backup should be done
+    cpt=0
+    for current_fs in $I_SRC_FSS ; do
 
-		cpt=$(($cpt+1))
-	
-		# for the current fs and all its sub-filesystems
-		for currentSubSrcFs in `$BIN_ZFS list -t filesystem,volume -r -H -o name $current_fs`; do
+        cpt=$(($cpt+1))
+    
+        # for the current fs and all its sub-filesystems
+        for currentSubSrcFs in `$BIN_ZFS list -t filesystem,volume -r -H -o name $current_fs`; do
 
-			currentSubDstFs="$I_DEST_FS/$currentSubSrcFs"
-		
-			# create the dest filesystems (recursively)
-			# if they do not yet exist and exit if it fails
-			if ! ensureRemoteFSExists "$currentSubDstFs"; then
-				returnCode=1
-			else
-				# if a compression algorithm was specified by the user
-				# set compression algorithm for the current destination fs
-				if [ -n "$I_COMPRESSION" ]; then
-					# compute compress algorithm for the current fs, or unique algorithm if only one was defined
-					algo=`echo "$I_COMPRESSION" | cut -f$cpt -d,`
-					if $RUN_CMD_SSH $BIN_ZFS set compression="$algo" "$currentSubDstFs" 2>/dev/null 1>/dev/null; then
-						log_info "$LOGFILE" "Compression algorithm set to \"$algo\" for \"$currentSubDstFs\""
-					else
-						log_error "$LOGFILE" "Could not set compression algorithm to \"$algo\" for \"$currentSubDstFs\""
-						returnCode=1
-					fi
-				fi
+            currentSubDstFs="$I_DEST_FS/$currentSubSrcFs"
+        
+            # create the dest filesystems (recursively)
+            # if they do not yet exist and exit if it fails
+            if ! ensureRemoteFSExists "$currentSubDstFs"; then
+                returnCode=1
+            else
+                # if a compression algorithm was specified by the user
+                # set compression algorithm for the current destination fs
+                if [ -n "$I_COMPRESSION" ]; then
+                    # compute compress algorithm for the current fs, or unique algorithm if only one was defined
+                    algo=`echo "$I_COMPRESSION" | cut -f$cpt -d,`
+                    if $RUN_CMD_SSH $BIN_ZFS set compression="$algo" "$currentSubDstFs" 2>/dev/null 1>/dev/null; then
+                        log_info "$LOGFILE" "Compression algorithm set to \"$algo\" for \"$currentSubDstFs\""
+                    else
+                        log_error "$LOGFILE" "Could not set compression algorithm to \"$algo\" for \"$currentSubDstFs\""
+                        returnCode=1
+                    fi
+                fi
 
-				# Perform the backup
-				if ! backup "$currentSubSrcFs" "$currentSubDstFs"; then
-					returnCode=1
-				fi
-			fi
-		done
-	done
+                # Perform the backup
+                if ! backup "$currentSubSrcFs" "$currentSubDstFs"; then
+                    returnCode=1
+                fi
+            fi
+        done
+    done
 
-	return $returnCode
+    return $returnCode
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	run_main "$LOGFILE" "$SCRIPT_NAME"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    run_main "$LOGFILE" "$SCRIPT_NAME"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/checkPools.sh
+++ b/checkPools.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"

--- a/checkPools.sh
+++ b/checkPools.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -34,72 +34,72 @@ ARGUMENTS="$@"
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local opt
-	
-	# parse the optional parameters
-	# (there should be none)
-	while getopts ":" opt; do
-        	case $opt in
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-        	esac
-	done
+    local opt
+    
+    # parse the optional parameters
+    # (there should be none)
+    while getopts ":" opt; do
+            case $opt in
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            esac
+    done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "0" ]; then
-		echo "No mandatory arguments should be provided"
-		return 1
-	fi
-	
-	return 0
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "0" ]; then
+        echo "No mandatory arguments should be provided"
+        return 1
+    fi
+    
+    return 0
 }
 
 ##################################
 # Scrub all pools
 # Return : 0 no problem detected
-#	   1 problem detected
+#       1 problem detected
 ##################################
 main() {
-	local pool
+    local pool
 
-	log_info "$LOGFILE" "Starting checking of pools"
-	
-	$BIN_ZPOOL list -H -o name | while read pool; do
-		if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | grep "is healthy">/dev/null; then
-			ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | log_info "$LOGFILE"
-		else
-			$BIN_ZPOOL status -v $pool | log_error "$LOGFILE"
-		fi
-	done
+    log_info "$LOGFILE" "Starting checking of pools"
+    
+    $BIN_ZPOOL list -H -o name | while read pool; do
+        if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | grep "is healthy">/dev/null; then
+            ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | log_info "$LOGFILE"
+        else
+            $BIN_ZPOOL status -v $pool | log_error "$LOGFILE"
+        fi
+    done
 
-	# Check if the pools are healthy
-	if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | grep "all pools are healthy">/dev/null; then
-		return 0
-	else
-		return 1
-	fi
+    # Check if the pools are healthy
+    if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | grep "all pools are healthy">/dev/null; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	run_main "$LOGFILE" "$SCRIPT_NAME"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    run_main "$LOGFILE" "$SCRIPT_NAME"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/checkPools.sh
+++ b/checkPools.sh
@@ -35,7 +35,7 @@ ARGUMENTS="$@"
 ##################################
 parseInputParams() {
     local opt
-    
+
     # parse the optional parameters
     # (there should be none)
     while getopts ":" opt; do
@@ -48,14 +48,14 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "0" ]; then
         echo "No mandatory arguments should be provided"
         return 1
     fi
-    
+
     return 0
 }
 
@@ -68,7 +68,7 @@ main() {
     local pool
 
     log_info "$LOGFILE" "Starting checking of pools"
-    
+
     $BIN_ZPOOL list -H -o name | while read pool; do
         if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | grep "is healthy">/dev/null; then
             ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x $pool | log_info "$LOGFILE"

--- a/checkSpace.sh
+++ b/checkSpace.sh
@@ -47,7 +47,7 @@ I_WARN_THRESHOLD="80"    # space warning threshold default value
 ##################################
 parseInputParams() {
     local opt fs_without_slash
-    
+
     # parse the parameters
     while getopts ":f:t:" opt; do
             case $opt in
@@ -79,14 +79,14 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "0" ]; then
         echo "No mandatory arguments should be provided"
         return 1
     fi
-    
+
     return 0
 }
 
@@ -146,7 +146,7 @@ main() {
     printf '%14s %13s %13s %13s %s\n' "Used (percent)" "Used (MiB)" "Available" "Quota" "Filesystem" \
         | log_info "$LOGFILE"
 
-    
+
     # Check the space for the filesystem (and for all sub-fs recursively)
     for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H -r -o name $I_FILESYSTEM`; do
 
@@ -156,12 +156,12 @@ main() {
         percent=$(($used*100/($used+$avail)))
 
         printf '%14s %13s %13s %13s %s\n' "$percent percent" "$((used/mib)) MiB" "$((avail/mib)) MiB" "$((quota/mib)) MiB" "$subfilesystem" \
-            | log_info "$LOGFILE"        
-        
-        # Check if the warning limit is reached        
+            | log_info "$LOGFILE"
+
+        # Check if the warning limit is reached
         if [ $percent -gt $I_WARN_THRESHOLD ] ; then
-            log_warning "$LOGFILE" "Notification threshold reached !"    
-            log_warning "$LOGFILE" "Consider increasing quota or adding disk space"    
+            log_warning "$LOGFILE" "Notification threshold reached !"
+            log_warning "$LOGFILE" "Consider increasing quota or adding disk space"
             returnCode=1
         fi
     done

--- a/checkSpace.sh
+++ b/checkSpace.sh
@@ -14,7 +14,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -36,8 +36,8 @@ LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.log"
 ARGUMENTS="$@"
 
 # Initialization of the optional input variables
-I_FILESYSTEM=""     # default name of the filesystem to be monitored (meaning: all fs)
-I_WARN_THRESHOLD="80"    # space warning threshold default value
+I_FILESYSTEM=""  # default name of the filesystem to be monitored (meaning: all fs)
+I_WARN_THRESHOLD="80"  # space warning threshold default value
 
 ##################################
 # Check script input parameters
@@ -51,9 +51,9 @@ parseInputParams() {
     # parse the parameters
     while getopts ":f:t:" opt; do
             case $opt in
-            f) fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
-                 LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"     # value of the log file name
-                 $BIN_ZFS list "$OPTARG" 2>/dev/null 1>/dev/null            # Check if the zfs file system exists
+            f) fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`  # value of the fs without '/' that is not allowed in a file name
+                 LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"  # value of the log file name
+                 $BIN_ZFS list "$OPTARG" 2>/dev/null 1>/dev/null  # Check if the zfs file system exists
                 if [ "$?" -eq "0" ] ; then
                     I_FILESYSTEM="$OPTARG"
                 else
@@ -180,7 +180,7 @@ else
     cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
     # run script if possible (lock not existing)
-    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`  # value of the fs without '/' that is not allowed in a file name
     run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
     # in case of error, send mail with extract of log file
     [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"

--- a/checkSpace.sh
+++ b/checkSpace.sh
@@ -6,15 +6,15 @@
 #
 # Usage: checkSpace.sh [-f filesystem] [-t threshold]
 #
-#	-f filesystem : the ZFS filesystem (incl. sub-fs) to be checked
-#			default: all ZFS filesystems
-# 	-t threshold : the threshold in percent above which a notification mail shall be sent
-#			value must be between 0 and 99
-#			default: 80 (percent)
+#    -f filesystem : the ZFS filesystem (incl. sub-fs) to be checked
+#            default: all ZFS filesystems
+#    -t threshold : the threshold in percent above which a notification mail shall be sent
+#            value must be between 0 and 99
+#            default: 80 (percent)
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -36,8 +36,8 @@ LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.log"
 ARGUMENTS="$@"
 
 # Initialization of the optional input variables
-I_FILESYSTEM="" 	# default name of the filesystem to be monitored (meaning: all fs)
-I_WARN_THRESHOLD="80"	# space warning threshold default value
+I_FILESYSTEM=""     # default name of the filesystem to be monitored (meaning: all fs)
+I_WARN_THRESHOLD="80"    # space warning threshold default value
 
 ##################################
 # Check script input parameters
@@ -46,48 +46,48 @@ I_WARN_THRESHOLD="80"	# space warning threshold default value
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local opt fs_without_slash
-	
-	# parse the parameters
-	while getopts ":f:t:" opt; do
-        	case $opt in
-			f)	fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`		# value of the fs without '/' that is not allowed in a file name
- 				LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log" 	# value of the log file name
- 				$BIN_ZFS list "$OPTARG" 2>/dev/null 1>/dev/null			# Check if the zfs file system exists
-				if [ "$?" -eq "0" ] ; then
-					I_FILESYSTEM="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -f. The ZFS filesystem does not exist."
-					return 1
-				fi ;;
-			t) 	# check if the threshold value is valid
-				echo "$OPTARG" | grep -E '^[0-9]{1,2}$' >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_WARN_THRESHOLD="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -t. Should be an integer between 0 and 99."
-					return 1
-				fi ;;
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-			:)
-				echo "Option -$OPTARG requires an argument"
-				return 1 ;;
-        	esac
-	done
+    local opt fs_without_slash
+    
+    # parse the parameters
+    while getopts ":f:t:" opt; do
+            case $opt in
+            f)    fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
+                 LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"     # value of the log file name
+                 $BIN_ZFS list "$OPTARG" 2>/dev/null 1>/dev/null            # Check if the zfs file system exists
+                if [ "$?" -eq "0" ] ; then
+                    I_FILESYSTEM="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -f. The ZFS filesystem does not exist."
+                    return 1
+                fi ;;
+            t)     # check if the threshold value is valid
+                echo "$OPTARG" | grep -E '^[0-9]{1,2}$' >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_WARN_THRESHOLD="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -t. Should be an integer between 0 and 99."
+                    return 1
+                fi ;;
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            :)
+                echo "Option -$OPTARG requires an argument"
+                return 1 ;;
+            esac
+    done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "0" ]; then
-		echo "No mandatory arguments should be provided"
-		return 1
-	fi
-	
-	return 0
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "0" ]; then
+        echo "No mandatory arguments should be provided"
+        return 1
+    fi
+    
+    return 0
 }
 
 ##################################
@@ -96,14 +96,14 @@ parseInputParams() {
 # Return : quota in byte (0 if no quota was set)
 ##################################
 getQuota() {
-	local fs q
-	fs="$1"
+    local fs q
+    fs="$1"
 
-	# compute the quota of the filesystem in byte
-	q=`$BIN_ZFS get -o value -Hp quota $fs`
-	# check if quota is not a number, for volumes it migh be "-"
-	! [ "$q" -eq "$q" ] 2>/dev/null && q="0"
-	echo $q
+    # compute the quota of the filesystem in byte
+    q=`$BIN_ZFS get -o value -Hp quota $fs`
+    # check if quota is not a number, for volumes it migh be "-"
+    ! [ "$q" -eq "$q" ] 2>/dev/null && q="0"
+    echo $q
 }
 
 ##################################
@@ -112,11 +112,11 @@ getQuota() {
 # Return : used space in byte
 ##################################
 getUsed() {
-	local fs
-	fs="$1"
+    local fs
+    fs="$1"
 
-	# compute the used size of the filesystem in byte
-	$BIN_ZFS get -o value -Hp used $fs
+    # compute the used size of the filesystem in byte
+    $BIN_ZFS get -o value -Hp used $fs
 }
 
 ##################################
@@ -125,65 +125,65 @@ getUsed() {
 # Return : available space in byte
 ##################################
 getAvailable() {
-	local fs
-	fs="$1"
+    local fs
+    fs="$1"
 
-	# compute the used size of the filesystem in byte
-	$BIN_ZFS get -o value -Hp avail $fs
+    # compute the used size of the filesystem in byte
+    $BIN_ZFS get -o value -Hp avail $fs
 }
 
 ##################################
 # Main
 ##################################
 main() {
-	local returnCode quota used avail percent mib
+    local returnCode quota used avail percent mib
 
-	returnCode=0
-	mib=$((1024*1024))
+    returnCode=0
+    mib=$((1024*1024))
 
-	log_info "$LOGFILE" "Configured warning threshold: $I_WARN_THRESHOLD percent"
+    log_info "$LOGFILE" "Configured warning threshold: $I_WARN_THRESHOLD percent"
 
-	printf '%14s %13s %13s %13s %s\n' "Used (percent)" "Used (MiB)" "Available" "Quota" "Filesystem" \
-		| log_info "$LOGFILE"
+    printf '%14s %13s %13s %13s %s\n' "Used (percent)" "Used (MiB)" "Available" "Quota" "Filesystem" \
+        | log_info "$LOGFILE"
 
-	
-	# Check the space for the filesystem (and for all sub-fs recursively)
-	for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H -r -o name $I_FILESYSTEM`; do
+    
+    # Check the space for the filesystem (and for all sub-fs recursively)
+    for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H -r -o name $I_FILESYSTEM`; do
 
-		quota=`getQuota $subfilesystem`
-		used=`getUsed $subfilesystem`
-		avail=`getAvailable $subfilesystem`
-		percent=$(($used*100/($used+$avail)))
+        quota=`getQuota $subfilesystem`
+        used=`getUsed $subfilesystem`
+        avail=`getAvailable $subfilesystem`
+        percent=$(($used*100/($used+$avail)))
 
-		printf '%14s %13s %13s %13s %s\n' "$percent percent" "$((used/mib)) MiB" "$((avail/mib)) MiB" "$((quota/mib)) MiB" "$subfilesystem" \
-			| log_info "$LOGFILE"		
-		
-		# Check if the warning limit is reached		
-		if [ $percent -gt $I_WARN_THRESHOLD ] ; then
-			log_warning "$LOGFILE" "Notification threshold reached !"	
-			log_warning "$LOGFILE" "Consider increasing quota or adding disk space"	
-			returnCode=1
-		fi
-	done
+        printf '%14s %13s %13s %13s %s\n' "$percent percent" "$((used/mib)) MiB" "$((avail/mib)) MiB" "$((quota/mib)) MiB" "$subfilesystem" \
+            | log_info "$LOGFILE"        
+        
+        # Check if the warning limit is reached        
+        if [ $percent -gt $I_WARN_THRESHOLD ] ; then
+            log_warning "$LOGFILE" "Notification threshold reached !"    
+            log_warning "$LOGFILE" "Consider increasing quota or adding disk space"    
+            returnCode=1
+        fi
+    done
 
-	return $returnCode
+    return $returnCode
 }
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    	# value of the fs without '/' that is not allowed in a file name
-	run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
+    run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/checkSpace.sh
+++ b/checkSpace.sh
@@ -51,7 +51,7 @@ parseInputParams() {
     # parse the parameters
     while getopts ":f:t:" opt; do
             case $opt in
-            f)    fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
+            f) fs_without_slash=`echo "$OPTARG" | sed 's!/!_!g'`        # value of the fs without '/' that is not allowed in a file name
                  LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"     # value of the log file name
                  $BIN_ZFS list "$OPTARG" 2>/dev/null 1>/dev/null            # Check if the zfs file system exists
                 if [ "$?" -eq "0" ] ; then
@@ -60,7 +60,7 @@ parseInputParams() {
                     echo "Invalid parameter \"$OPTARG\" for option: -f. The ZFS filesystem does not exist."
                     return 1
                 fi ;;
-            t)     # check if the threshold value is valid
+            t) # check if the threshold value is valid
                 echo "$OPTARG" | grep -E '^[0-9]{1,2}$' >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_WARN_THRESHOLD="$OPTARG"

--- a/checkTemp.sh
+++ b/checkTemp.sh
@@ -12,7 +12,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"

--- a/checkTemp.sh
+++ b/checkTemp.sh
@@ -7,12 +7,12 @@
 #
 # Usage: checkTemp.sh thresholdCPU thresholdHDD
 #
-#	thresholdCPU : Warning temperature threshold to the CPU (in deg celsius)
-# 	thresholdHDD : Warning temperature threshold to the HDD (in deg celsius)
+#    thresholdCPU : Warning temperature threshold to the CPU (in deg celsius)
+#    thresholdHDD : Warning temperature threshold to the HDD (in deg celsius)
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -40,31 +40,31 @@ ARGUMENTS="$@"
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local opt regex_temp
+    local opt regex_temp
 
-	# parse the optional parameters
-	# (there should be none)
-	while getopts ":" opt; do
-        	case $opt in
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-        	esac
-	done
+    # parse the optional parameters
+    # (there should be none)
+    while getopts ":" opt; do
+            case $opt in
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            esac
+    done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "2" ]; then
-		echo "$LOGFILE" "Exactly two mandatory argument shall be provided"
-		return 1
-	fi
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "2" ]; then
+        echo "$LOGFILE" "Exactly two mandatory argument shall be provided"
+        return 1
+    fi
 
-	# Set variables corresponding to the input parameters
-	I_WARN_THRESHOLD_CPU="$1"
-	I_WARN_THRESHOLD_HDD="$2"
+    # Set variables corresponding to the input parameters
+    I_WARN_THRESHOLD_CPU="$1"
+    I_WARN_THRESHOLD_HDD="$2"
 
         regex_temp="([0-9]+)"
 
@@ -80,7 +80,7 @@ parseInputParams() {
                 return 1
         fi
 
-	return 0
+    return 0
 }
 
 
@@ -88,57 +88,57 @@ parseInputParams() {
 # Main
 ##################################
 main() {
-	returnCode=0
-	
-	log_info "$LOGFILE" "Starting checking temperatures..."
-	
-	log_info "$LOGFILE" "CPUs (warning threshold: $((I_WARN_THRESHOLD_CPU))C):"
-	printf '%8s %s\n' "Temp(C)" "CPU" | log_info "$LOGFILE"
-	for cpu in `sysctl -a | grep -E "cpu\.[0-9]+\.temp" | cut -f1 -d:`; do
-		cpuTemp=`sysctl -a | grep $cpu | awk '{gsub(/[.][0-9]*C/,"");print $2}'`
-		
-		printf '%+8d %s\n' "$((cpuTemp))" "$cpu" | log_info "$LOGFILE"
-		
-		if [ "$((cpuTemp))" -ge "$I_WARN_THRESHOLD_CPU" ] ; then
-			log_warning "$LOGFILE" "CPU notification threshold reached !"
-			returnCode=1
-		fi
-	done
+    returnCode=0
+    
+    log_info "$LOGFILE" "Starting checking temperatures..."
+    
+    log_info "$LOGFILE" "CPUs (warning threshold: $((I_WARN_THRESHOLD_CPU))C):"
+    printf '%8s %s\n' "Temp(C)" "CPU" | log_info "$LOGFILE"
+    for cpu in `sysctl -a | grep -E "cpu\.[0-9]+\.temp" | cut -f1 -d:`; do
+        cpuTemp=`sysctl -a | grep $cpu | awk '{gsub(/[.][0-9]*C/,"");print $2}'`
+        
+        printf '%+8d %s\n' "$((cpuTemp))" "$cpu" | log_info "$LOGFILE"
+        
+        if [ "$((cpuTemp))" -ge "$I_WARN_THRESHOLD_CPU" ] ; then
+            log_warning "$LOGFILE" "CPU notification threshold reached !"
+            returnCode=1
+        fi
+    done
 
-	log_info "$LOGFILE" "HDDs (warning threshold: $((I_WARN_THRESHOLD_HDD))C):"
-	printf '%8s %-6s %-25s %s\n' "Temp(C)" "dev" "P/N" "S/N" | log_info "$LOGFILE"
-	for hdd in $(sysctl -n kern.disks); do
-		devTemp=`$BIN_SMARTCTL -a /dev/$hdd | grep "Temperature_Celsius" | awk '{print $10}'`
-		devSerNum=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Serial Number:" | sed 's/^Serial Number:[ \t]*\(.*\)[ \t]*$/\1/g'`
-		devName=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Device Model:" | sed 's/^Device Model:[ \t]*\(.*\)[ \t]*$/\1/g'`
-		
-		printf '%+8d %-6s %-25s %s\n' "$((devTemp))" "$hdd" "$devName" "$devSerNum" \
-			| log_info "$LOGFILE"
-			
-		if [ "$((devTemp))" -ge "$I_WARN_THRESHOLD_HDD" ] ; then
-			log_warning "$LOGFILE" "HDD notification threshold reached !"
-			returnCode=1
-		fi
-	done
-	
-	return $returnCode
+    log_info "$LOGFILE" "HDDs (warning threshold: $((I_WARN_THRESHOLD_HDD))C):"
+    printf '%8s %-6s %-25s %s\n' "Temp(C)" "dev" "P/N" "S/N" | log_info "$LOGFILE"
+    for hdd in $(sysctl -n kern.disks); do
+        devTemp=`$BIN_SMARTCTL -a /dev/$hdd | grep "Temperature_Celsius" | awk '{print $10}'`
+        devSerNum=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Serial Number:" | sed 's/^Serial Number:[ \t]*\(.*\)[ \t]*$/\1/g'`
+        devName=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Device Model:" | sed 's/^Device Model:[ \t]*\(.*\)[ \t]*$/\1/g'`
+        
+        printf '%+8d %-6s %-25s %s\n' "$((devTemp))" "$hdd" "$devName" "$devSerNum" \
+            | log_info "$LOGFILE"
+            
+        if [ "$((devTemp))" -ge "$I_WARN_THRESHOLD_HDD" ] ; then
+            log_warning "$LOGFILE" "HDD notification threshold reached !"
+            returnCode=1
+        fi
+    done
+    
+    return $returnCode
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	run_main "$LOGFILE" "$SCRIPT_NAME"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    run_main "$LOGFILE" "$SCRIPT_NAME"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/checkTemp.sh
+++ b/checkTemp.sh
@@ -54,7 +54,7 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "2" ]; then
@@ -89,16 +89,16 @@ parseInputParams() {
 ##################################
 main() {
     returnCode=0
-    
+
     log_info "$LOGFILE" "Starting checking temperatures..."
-    
+
     log_info "$LOGFILE" "CPUs (warning threshold: $((I_WARN_THRESHOLD_CPU))C):"
     printf '%8s %s\n' "Temp(C)" "CPU" | log_info "$LOGFILE"
     for cpu in `sysctl -a | grep -E "cpu\.[0-9]+\.temp" | cut -f1 -d:`; do
         cpuTemp=`sysctl -a | grep $cpu | awk '{gsub(/[.][0-9]*C/,"");print $2}'`
-        
+
         printf '%+8d %s\n' "$((cpuTemp))" "$cpu" | log_info "$LOGFILE"
-        
+
         if [ "$((cpuTemp))" -ge "$I_WARN_THRESHOLD_CPU" ] ; then
             log_warning "$LOGFILE" "CPU notification threshold reached !"
             returnCode=1
@@ -111,16 +111,16 @@ main() {
         devTemp=`$BIN_SMARTCTL -a /dev/$hdd | grep "Temperature_Celsius" | awk '{print $10}'`
         devSerNum=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Serial Number:" | sed 's/^Serial Number:[ \t]*\(.*\)[ \t]*$/\1/g'`
         devName=`$BIN_SMARTCTL -a /dev/$hdd | grep "^Device Model:" | sed 's/^Device Model:[ \t]*\(.*\)[ \t]*$/\1/g'`
-        
+
         printf '%+8d %-6s %-25s %s\n' "$((devTemp))" "$hdd" "$devName" "$devSerNum" \
             | log_info "$LOGFILE"
-            
+
         if [ "$((devTemp))" -ge "$I_WARN_THRESHOLD_HDD" ] ; then
             log_warning "$LOGFILE" "HDD notification threshold reached !"
             returnCode=1
         fi
     done
-    
+
     return $returnCode
 }
 

--- a/common/commonLockFcts.sh
+++ b/common/commonLockFcts.sh
@@ -20,73 +20,73 @@
 #          3 if it is not possible to create the folder that shall contain all locks
 ##################################
 acquire_lock() {
-	local lock_id
-	lock_id="$1"
+    local lock_id
+    lock_id="$1"
 
-	# Ensure that the folder that shall contain all locks exists
-	if ! ensure_lock_folder_exits; then
-		return 3
-	fi
-	
-	# If no lock is allowed to be acquired
-	if [ -f "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE" ]; then
-		return 2
-	fi
+    # Ensure that the folder that shall contain all locks exists
+    if ! ensure_lock_folder_exits; then
+        return 3
+    fi
+    
+    # If no lock is allowed to be acquired
+    if [ -f "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE" ]; then
+        return 2
+    fi
 
-	# acquire the lock
-	if $BIN_MKDIR "`get_lock_path $lock_id`" 2>/dev/null; then
-		return 0
-	else
-		return 1
-	fi
+    # acquire the lock
+    if $BIN_MKDIR "`get_lock_path $lock_id`" 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 ##################################
 # Release a lock that was acquired before
 #
 # Param 1: lock id (must be the same id, as the id
-#	   provided when the lock was acquired)
+#       provided when the lock was acquired)
 # Return : 0 if the lock could be released
 #          1 otherwise
 ##################################
 release_lock() {
-	local lock_id
-	lock_id="$1"
+    local lock_id
+    lock_id="$1"
 
-	# Ensure that the folder that shall contain all locks exists
-	if ! ensure_lock_folder_exits; then
- 		return 1
-	fi
+    # Ensure that the folder that shall contain all locks exists
+    if ! ensure_lock_folder_exits; then
+         return 1
+    fi
 
-	# Release the lock
-	if $BIN_RM -r "`get_lock_path $lock_id`" 2>/dev/null; then
-		return 0
-	else
-		return 1
-	fi
+    # Release the lock
+    if $BIN_RM -r "`get_lock_path $lock_id`" 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 ##################################
 # Check if any lock exists currently
 #
 # Return : 0 if at least one lock exists
-# 	   1 if no lock exists
+#        1 if no lock exists
 ##################################
 does_any_lock_exist() {
 
-	# If the folder that shall contain all locks cannot be created,
-	# then no lock can exist
-	# (this case should not happen)
-	if ! ensure_lock_folder_exits; then
- 		return 1
-	fi
+    # If the folder that shall contain all locks cannot be created,
+    # then no lock can exist
+    # (this case should not happen)
+    if ! ensure_lock_folder_exits; then
+         return 1
+    fi
 
-	# check if any lock exists
-	if [ "`$BIN_LS -A $CFG_LOCKS_FOLDER`" != "" ]; then
-		return 0
-	else
-		return 1
-	fi
+    # check if any lock exists
+    if [ "`$BIN_LS -A $CFG_LOCKS_FOLDER`" != "" ]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 ##################################
@@ -95,7 +95,7 @@ does_any_lock_exist() {
 # Return : The list of locks
 ##################################
 get_list_of_locks() {
-	$BIN_LS -A "$CFG_LOCKS_FOLDER" | $BIN_TR "\n" ";"
+    $BIN_LS -A "$CFG_LOCKS_FOLDER" | $BIN_TR "\n" ";"
 }
 
 ##################################
@@ -104,7 +104,7 @@ get_list_of_locks() {
 # acquire_lock() function will always return 1
 ##################################
 prevent_acquire_locks() {
-	echo "No lock allowed to be acquired since: `$BIN_DATE`" > "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE"
+    echo "No lock allowed to be acquired since: `$BIN_DATE`" > "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE"
 }
 
 ##################################
@@ -112,7 +112,7 @@ prevent_acquire_locks() {
 # unless it was already acquired
 ##################################
 allow_acquire_locks() {
-	$BIN_RM -f "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE"
+    $BIN_RM -f "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE"
 }
 
 ##################################
@@ -120,8 +120,8 @@ allow_acquire_locks() {
 # This function may be called at NAS startup for robustness reasons
 ##################################
 reset_locks() {
-	allow_acquire_locks
-	$BIN_RM -f -r "$CFG_LOCKS_FOLDER"
+    allow_acquire_locks
+    $BIN_RM -f -r "$CFG_LOCKS_FOLDER"
 }
 
 ##################################
@@ -132,8 +132,8 @@ reset_locks() {
 #          1 if the folder could not be created
 ##################################
 ensure_lock_folder_exits() {
-	$BIN_MKDIR -p -m go-w "$CFG_LOCKS_FOLDER"
-	return $?
+    $BIN_MKDIR -p -m go-w "$CFG_LOCKS_FOLDER"
+    return $?
 }
 
 ##################################
@@ -143,10 +143,10 @@ ensure_lock_folder_exits() {
 # Return : the lock path
 ##################################
 get_lock_path() {
-	local lock_id
-	lock_id="$1"
+    local lock_id
+    lock_id="$1"
 
-	echo "$CFG_LOCKS_FOLDER/$lock_id.lock"
+    echo "$CFG_LOCKS_FOLDER/$lock_id.lock"
 }
 
 ##################################
@@ -157,47 +157,47 @@ get_lock_path() {
 # Param 2: lock id (should be a folder name without its path)
 # Return : 0 : no error
 #          1 : could not start script because the system is (probably) about to shutdown
-#	   2 : any other error
+#       2 : any other error
 ##################################
 run_main() {
-	local log_file lock_id retCodeAcquireLock errInMain
+    local log_file lock_id retCodeAcquireLock errInMain
 
-	log_file="$1"
-	lock_id="$2"
+    log_file="$1"
+    lock_id="$2"
 
-	errInMain=0
-	
-	# acquire lock and run main
-	acquire_lock "$lock_id"
-	retCodeAcquireLock="$?"
-	if [ "$retCodeAcquireLock" -eq "0" ]; then
-		! main && errInMain=1
-	elif [ "$retCodeAcquireLock" -eq "1" ]; then
-		log_error "$log_file" "Could not start script: Another instance is running or stopped abnormally"
-		log_error "$log_file" "In the latter case, please delete manually the corresponding lock: \"`get_lock_path $lock_id`\""
-		return 2
-	elif [ "$retCodeAcquireLock" -eq "2" ]; then
-		log_info "$log_file" "Could not start script (The system is probably about to shutdown)"
-		return 1
-	elif [ "$retCodeAcquireLock" -eq "3" ]; then
-		log_error "$log_file" "Lock folder \"$CFG_LOCKS_FOLDER\" could not be created"
-		return 2	
-	else
-		log_error "$log_file" "Could not start script (Unexpected issue)"
-		return 2
-	fi
+    errInMain=0
+    
+    # acquire lock and run main
+    acquire_lock "$lock_id"
+    retCodeAcquireLock="$?"
+    if [ "$retCodeAcquireLock" -eq "0" ]; then
+        ! main && errInMain=1
+    elif [ "$retCodeAcquireLock" -eq "1" ]; then
+        log_error "$log_file" "Could not start script: Another instance is running or stopped abnormally"
+        log_error "$log_file" "In the latter case, please delete manually the corresponding lock: \"`get_lock_path $lock_id`\""
+        return 2
+    elif [ "$retCodeAcquireLock" -eq "2" ]; then
+        log_info "$log_file" "Could not start script (The system is probably about to shutdown)"
+        return 1
+    elif [ "$retCodeAcquireLock" -eq "3" ]; then
+        log_error "$log_file" "Lock folder \"$CFG_LOCKS_FOLDER\" could not be created"
+        return 2    
+    else
+        log_error "$log_file" "Could not start script (Unexpected issue)"
+        return 2
+    fi
 
-	# release lock
-	if ! release_lock "$lock_id"; then
-		log_error "$log_file" "Could not delete lock at end of execution"
-		return 2
-	fi	
-	
-	# return code of main
-	if [ "$errInMain" -ne "0" ]; then
-		return 2
-	else
-		return 0
-	fi
+    # release lock
+    if ! release_lock "$lock_id"; then
+        log_error "$log_file" "Could not delete lock at end of execution"
+        return 2
+    fi    
+    
+    # return code of main
+    if [ "$errInMain" -ne "0" ]; then
+        return 2
+    else
+        return 0
+    fi
 }
 

--- a/common/commonLockFcts.sh
+++ b/common/commonLockFcts.sh
@@ -27,7 +27,7 @@ acquire_lock() {
     if ! ensure_lock_folder_exits; then
         return 3
     fi
-    
+
     # If no lock is allowed to be acquired
     if [ -f "$CFG_FORBID_ANY_LOCK_ACQUISITION_FILE" ]; then
         return 2
@@ -166,7 +166,7 @@ run_main() {
     lock_id="$2"
 
     errInMain=0
-    
+
     # acquire lock and run main
     acquire_lock "$lock_id"
     retCodeAcquireLock="$?"
@@ -181,7 +181,7 @@ run_main() {
         return 1
     elif [ "$retCodeAcquireLock" -eq "3" ]; then
         log_error "$log_file" "Lock folder \"$CFG_LOCKS_FOLDER\" could not be created"
-        return 2    
+        return 2
     else
         log_error "$log_file" "Could not start script (Unexpected issue)"
         return 2
@@ -191,8 +191,8 @@ run_main() {
     if ! release_lock "$lock_id"; then
         log_error "$log_file" "Could not delete lock at end of execution"
         return 2
-    fi    
-    
+    fi
+
     # return code of main
     if [ "$errInMain" -ne "0" ]; then
         return 2

--- a/common/commonLogFcts.sh
+++ b/common/commonLogFcts.sh
@@ -14,91 +14,91 @@ readonly LOG_ERROR="ERROR"
 # Format of the timestamp used in the log files
 ##################################
 ts_format() {
-	echo "%Y%m%d_%H%M%S"
+    echo "%Y%m%d_%H%M%S"
 }
 
 ##################################
 # Append an information message in a log file
-# 	The 2nd argument is optional, the function can also
-#	read data from the pipe
+#     The 2nd argument is optional, the function can also
+#    read data from the pipe
 # Param 1: log file name (incl. path)
 # Param 2: text to be logged
 ##################################
 log_info() {
-	log "$LOG_INFO" "$@"
+    log "$LOG_INFO" "$@"
 }
 
 ##################################
 # Append a warning message in a log file
-# 	The 2nd argument is optional, the function can also
-#	read data from the pipe
+#     The 2nd argument is optional, the function can also
+#    read data from the pipe
 # Param 1: log file name (incl. path)
 # Param 2: text to be logged
 ##################################
 log_warning() {
-	log "$LOG_WARNING" "$@"
+    log "$LOG_WARNING" "$@"
 }
 
 ##################################
 # Append an information message in a log file
-# 	The 2nd argument is optional, the function can also
-#	read data from the pipe
+#     The 2nd argument is optional, the function can also
+#    read data from the pipe
 # Param 1: log file name (incl. path)
 # Param 2: text to be logged
 ##################################
 log_error() {
-	log "$LOG_ERROR" "$@"
+    log "$LOG_ERROR" "$@"
 }
 
 ##################################
 # Append a line into a log file
-# 	The 3rd argument is optional, the function can also
-#	read data from the pipe
+#     The 3rd argument is optional, the function can also
+#    read data from the pipe
 # Param 1: message criticality
 # Param 2: path to the log file
 # Param 3: message to be logged (optional)
 # return: 1 if a bad log file path was provided
-#	  0 otherwise
+#      0 otherwise
 ##################################
 log() {
-	local criticality logfile text line local_ifs returnCode
-	criticality="$1"
-	logfile="$2"
-	
-	# If the text to be logged was provided through as the 3rd argument
-	if [ -n "$3" ]; then
-		text=`format_log_txt "$criticality" "$3"`
-		if [ -z "$logfile" ]; then
-			echo "EMPTY LOG FILE NAME: $text"
-			return 1
-		elif ! echo "$logfile" | grep ".*[.]log$" >/dev/null; then
-			echo "BAD LOG FILE EXTENSION ($logfile): $text"
-			return 1
-		elif [ ! -d `dirname "$logfile"` ]; then
-			echo "LOG DIR NOT EXISTING ($logfile): $text"
-			return 1		
-		else
-			echo "$text" >> $logfile
-			return 0
-		fi
+    local criticality logfile text line local_ifs returnCode
+    criticality="$1"
+    logfile="$2"
+    
+    # If the text to be logged was provided through as the 3rd argument
+    if [ -n "$3" ]; then
+        text=`format_log_txt "$criticality" "$3"`
+        if [ -z "$logfile" ]; then
+            echo "EMPTY LOG FILE NAME: $text"
+            return 1
+        elif ! echo "$logfile" | grep ".*[.]log$" >/dev/null; then
+            echo "BAD LOG FILE EXTENSION ($logfile): $text"
+            return 1
+        elif [ ! -d `dirname "$logfile"` ]; then
+            echo "LOG DIR NOT EXISTING ($logfile): $text"
+            return 1        
+        else
+            echo "$text" >> $logfile
+            return 0
+        fi
 
-	# If the text to be logged was provided through the pipe
-	else	
-		# IFS need to be changed so that the read cmd does not remove leading spaces
-		local_ifs="$IFS"
-		IFS=""	
-		
-		returnCode="0"
-		while read line; do
-			# recursive call with pipe to avoid to handle this case specially
-			log "$criticality" "$logfile" "$line" || returnCode="1"
-		done
-		
-		# setting IFS back to its initial value
-		IFS="$local_ifs"
-	
-		return "$returnCode"
-	fi
+    # If the text to be logged was provided through the pipe
+    else    
+        # IFS need to be changed so that the read cmd does not remove leading spaces
+        local_ifs="$IFS"
+        IFS=""    
+        
+        returnCode="0"
+        while read line; do
+            # recursive call with pipe to avoid to handle this case specially
+            log "$criticality" "$logfile" "$line" || returnCode="1"
+        done
+        
+        # setting IFS back to its initial value
+        IFS="$local_ifs"
+    
+        return "$returnCode"
+    fi
 }
 
 ##################################
@@ -108,18 +108,18 @@ log() {
 ##################################
 format_log_txt() {
 
-	local criticality text timestamp criticality_txt
+    local criticality text timestamp criticality_txt
 
-	criticality="$1"
-	text="$2"
+    criticality="$1"
+    text="$2"
 
-	tsFormat=`ts_format`
+    tsFormat=`ts_format`
 
-	timestamp=`$BIN_DATE +$tsFormat`
-		
-	echo "$timestamp	$criticality	$text"
+    timestamp=`$BIN_DATE +$tsFormat`
+        
+    echo "$timestamp    $criticality    $text"
 
-	return 0	
+    return 0    
 }
 
 
@@ -129,35 +129,35 @@ format_log_txt() {
 #
 # Param 1: file path
 # Return : 0 if no error occured
-#	   1 if the log file does not exist
-#	   2 if the timestamp could not be computed
+#       1 if the log file does not exist
+#       2 if the timestamp could not be computed
 ##################################
 get_log_oldest_ts() {
 
-	local f timestamp timestamp1970 tsFormat ret_code
-	
-	f="$1"
-	tsFormat=`ts_format`
-	
-	# Check if the file exists
-	if [ ! -s "$f" ]; then
-		echo "The file \"$f\" does not exists"
-		return 1
-	fi
+    local f timestamp timestamp1970 tsFormat ret_code
+    
+    f="$1"
+    tsFormat=`ts_format`
+    
+    # Check if the file exists
+    if [ ! -s "$f" ]; then
+        echo "The file \"$f\" does not exists"
+        return 1
+    fi
 
-	# get the timestamp of the 1st log entry	
-	timestamp=`sed "1"!d "$f" | awk '{ print $1 }'`
- 	timestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
-	ret_code="$?"	
+    # get the timestamp of the 1st log entry    
+    timestamp=`sed "1"!d "$f" | awk '{ print $1 }'`
+     timestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
+    ret_code="$?"    
 
-	# check if the timestamp1970 could be extracted
-	if [ "$ret_code" -eq "0" ]; then
-		echo $timestamp1970
-		return 0
-	else
-		echo "Timestamp could not be extracted of the log file"
-		return 2
-	fi
+    # check if the timestamp1970 could be extracted
+    if [ "$ret_code" -eq "0" ]; then
+        echo $timestamp1970
+        return 0
+    else
+        echo "Timestamp could not be extracted of the log file"
+        return 2
+    fi
 }
 
 
@@ -170,21 +170,21 @@ get_log_oldest_ts() {
 # Param 1: file path
 # Param 2: duration (in seconds)
 # Return : 0 if no error occurs
-#	   1 if the log file does not exist
-#	   2 if the log file does not contain any entry that is newer than
-#		the given timestamp
+#       1 if the log file does not exist
+#       2 if the log file does not contain any entry that is newer than
+#        the given timestamp
 ##################################
 get_log_entries() {
-	local f t
+    local f t
 
-	f="$1"
-	t="$2"
+    f="$1"
+    t="$2"
 
-	targetTimestamp1970=`$BIN_DATE -j -v-"$t"S +"%s"`
+    targetTimestamp1970=`$BIN_DATE -j -v-"$t"S +"%s"`
 
-	get_log_entries_ts "$f" "$targetTimestamp1970"
+    get_log_entries_ts "$f" "$targetTimestamp1970"
 
-	return "$?"	
+    return "$?"    
 }
 
 ##################################
@@ -195,96 +195,96 @@ get_log_entries() {
 # Param 1: file path
 # Param 2: timestamp (in seconds since 1970)
 # Return : 0 if no error occurs
-#	   1 if the log file does not exist
-#	   2 if the log file does not contain any entry that is newer than
-#		the given timestamp
+#       1 if the log file does not exist
+#       2 if the log file does not contain any entry that is newer than
+#        the given timestamp
 ##################################
 get_log_entries_ts() {
-	local f targetTimestamp1970 tsFormat nbLinesInFile firstLine lastLine diffLines \
-		midLine currentLine timestamp currentTimestamp1970 diffTimestamp \
-		firstLineTimestamp1970 diffFirstLineTimestamp lastLineTimestamp1970 diffLastLineTimestamp
-	
-	f="$1"
-	targetTimestamp1970="$2"
+    local f targetTimestamp1970 tsFormat nbLinesInFile firstLine lastLine diffLines \
+        midLine currentLine timestamp currentTimestamp1970 diffTimestamp \
+        firstLineTimestamp1970 diffFirstLineTimestamp lastLineTimestamp1970 diffLastLineTimestamp
+    
+    f="$1"
+    targetTimestamp1970="$2"
 
-	tsFormat=`ts_format`
-	
-	# Check if the file exists
-	if [ ! -s "$f" ]; then
-		echo "Impossible to retrieve log file, the file \"$f\" does not exists"
-		return 1
-	fi
+    tsFormat=`ts_format`
+    
+    # Check if the file exists
+    if [ ! -s "$f" ]; then
+        echo "Impossible to retrieve log file, the file \"$f\" does not exists"
+        return 1
+    fi
 
-	nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`	# find number of lines	
+    nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`    # find number of lines    
 
-	# if the file does not contain at least 1 line
-	if [ "$nbLinesInFile" -lt "1" ]; then
-		echo "No data available in the log file"
-		return 2	
-	fi
-	
- 	firstLine=1
-	lastLine=$nbLinesInFile
-	diffLines=$(($lastLine-$firstLine))
+    # if the file does not contain at least 1 line
+    if [ "$nbLinesInFile" -lt "1" ]; then
+        echo "No data available in the log file"
+        return 2    
+    fi
+    
+     firstLine=1
+    lastLine=$nbLinesInFile
+    diffLines=$(($lastLine-$firstLine))
 
-	# Find the oldest line to be returned using dichotomy
-	while [ "$diffLines" -gt "1" ]
-	do
+    # Find the oldest line to be returned using dichotomy
+    while [ "$diffLines" -gt "1" ]
+    do
 
-		# get the line in the middle of the 1st and last one
-		midLine=$((($lastLine+$firstLine)/2))
-		currentLine=`sed "$midLine"!d "$f"`
+        # get the line in the middle of the 1st and last one
+        midLine=$((($lastLine+$firstLine)/2))
+        currentLine=`sed "$midLine"!d "$f"`
 
-		# get the timestamp of the line	
-		timestamp=`echo "$currentLine" | awk '{ print $1 }'`
- 		currentTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
+        # get the timestamp of the line    
+        timestamp=`echo "$currentLine" | awk '{ print $1 }'`
+        currentTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
 
-		if [ "$?" -ne "0" ]; then
-			echo "Bad timestamp format ($timestamp) in log file. Skipping file"
-			return 1
-		fi
+        if [ "$?" -ne "0" ]; then
+            echo "Bad timestamp format ($timestamp) in log file. Skipping file"
+            return 1
+        fi
 
-		# decide which range shall be taken next
-		diffTimestamp=$(($targetTimestamp1970-$currentTimestamp1970))
+        # decide which range shall be taken next
+        diffTimestamp=$(($targetTimestamp1970-$currentTimestamp1970))
 
-		if [ "$diffTimestamp" -gt "0" ]; then
-			firstLine=$midLine
-			lastLine=$lastLine
-		else
-			firstLine=$firstLine
-			lastLine=$midLine
-		fi
+        if [ "$diffTimestamp" -gt "0" ]; then
+            firstLine=$midLine
+            lastLine=$lastLine
+        else
+            firstLine=$firstLine
+            lastLine=$midLine
+        fi
 
-		diffLines=$(($lastLine-$firstLine))
-	done
-
-
-	# Now diffLines should equal 1 or 0
-
-	currentLine=`sed "$firstLine"!d "$f"`
-	timestamp=`echo "$currentLine" | awk '{ print $1 }'`
-	firstLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
-	diffFirstLineTimestamp=$(($targetTimestamp1970-$firstLineTimestamp1970))
-	
-	currentLine=`sed "$lastLine"!d "$f"`
-	timestamp=`echo "$currentLine" | awk '{ print $1 }'`
-	lastLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
-	diffLastLineTimestamp=$(($targetTimestamp1970-$lastLineTimestamp1970))
+        diffLines=$(($lastLine-$firstLine))
+    done
 
 
-	# refine the part of the log should be returned
-	# If firstLine is new enough
-	if [ "$diffFirstLineTimestamp" -le "0" ]; then
-		tail -n $(($nbLinesInFile-$firstLine+1)) "$f"
-	# If lastLine is new enough
-	elif [ "$diffLastLineTimestamp" -le "0" ]; then
-		tail -n $(($nbLinesInFile-$lastLine+1)) "$f"
-	# Even the last line in the log is too old
-	else
-		echo "The data available in the log file are too old"
-		return 2
-	fi
+    # Now diffLines should equal 1 or 0
 
-	return 0
+    currentLine=`sed "$firstLine"!d "$f"`
+    timestamp=`echo "$currentLine" | awk '{ print $1 }'`
+    firstLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
+    diffFirstLineTimestamp=$(($targetTimestamp1970-$firstLineTimestamp1970))
+    
+    currentLine=`sed "$lastLine"!d "$f"`
+    timestamp=`echo "$currentLine" | awk '{ print $1 }'`
+    lastLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
+    diffLastLineTimestamp=$(($targetTimestamp1970-$lastLineTimestamp1970))
+
+
+    # refine the part of the log should be returned
+    # If firstLine is new enough
+    if [ "$diffFirstLineTimestamp" -le "0" ]; then
+        tail -n $(($nbLinesInFile-$firstLine+1)) "$f"
+    # If lastLine is new enough
+    elif [ "$diffLastLineTimestamp" -le "0" ]; then
+        tail -n $(($nbLinesInFile-$lastLine+1)) "$f"
+    # Even the last line in the log is too old
+    else
+        echo "The data available in the log file are too old"
+        return 2
+    fi
+
+    return 0
 }
 

--- a/common/commonLogFcts.sh
+++ b/common/commonLogFcts.sh
@@ -64,7 +64,7 @@ log() {
     local criticality logfile text line local_ifs returnCode
     criticality="$1"
     logfile="$2"
-    
+
     # If the text to be logged was provided through as the 3rd argument
     if [ -n "$3" ]; then
         text=`format_log_txt "$criticality" "$3"`
@@ -76,27 +76,27 @@ log() {
             return 1
         elif [ ! -d `dirname "$logfile"` ]; then
             echo "LOG DIR NOT EXISTING ($logfile): $text"
-            return 1        
+            return 1
         else
             echo "$text" >> $logfile
             return 0
         fi
 
     # If the text to be logged was provided through the pipe
-    else    
+    else
         # IFS need to be changed so that the read cmd does not remove leading spaces
         local_ifs="$IFS"
-        IFS=""    
-        
+        IFS=""
+
         returnCode="0"
         while read line; do
             # recursive call with pipe to avoid to handle this case specially
             log "$criticality" "$logfile" "$line" || returnCode="1"
         done
-        
+
         # setting IFS back to its initial value
         IFS="$local_ifs"
-    
+
         return "$returnCode"
     fi
 }
@@ -116,10 +116,10 @@ format_log_txt() {
     tsFormat=`ts_format`
 
     timestamp=`$BIN_DATE +$tsFormat`
-        
+
     echo "$timestamp    $criticality    $text"
 
-    return 0    
+    return 0
 }
 
 
@@ -135,20 +135,20 @@ format_log_txt() {
 get_log_oldest_ts() {
 
     local f timestamp timestamp1970 tsFormat ret_code
-    
+
     f="$1"
     tsFormat=`ts_format`
-    
+
     # Check if the file exists
     if [ ! -s "$f" ]; then
         echo "The file \"$f\" does not exists"
         return 1
     fi
 
-    # get the timestamp of the 1st log entry    
+    # get the timestamp of the 1st log entry
     timestamp=`sed "1"!d "$f" | awk '{ print $1 }'`
      timestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
-    ret_code="$?"    
+    ret_code="$?"
 
     # check if the timestamp1970 could be extracted
     if [ "$ret_code" -eq "0" ]; then
@@ -184,7 +184,7 @@ get_log_entries() {
 
     get_log_entries_ts "$f" "$targetTimestamp1970"
 
-    return "$?"    
+    return "$?"
 }
 
 ##################################
@@ -203,26 +203,26 @@ get_log_entries_ts() {
     local f targetTimestamp1970 tsFormat nbLinesInFile firstLine lastLine diffLines \
         midLine currentLine timestamp currentTimestamp1970 diffTimestamp \
         firstLineTimestamp1970 diffFirstLineTimestamp lastLineTimestamp1970 diffLastLineTimestamp
-    
+
     f="$1"
     targetTimestamp1970="$2"
 
     tsFormat=`ts_format`
-    
+
     # Check if the file exists
     if [ ! -s "$f" ]; then
         echo "Impossible to retrieve log file, the file \"$f\" does not exists"
         return 1
     fi
 
-    nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`    # find number of lines    
+    nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`    # find number of lines
 
     # if the file does not contain at least 1 line
     if [ "$nbLinesInFile" -lt "1" ]; then
         echo "No data available in the log file"
-        return 2    
+        return 2
     fi
-    
+
      firstLine=1
     lastLine=$nbLinesInFile
     diffLines=$(($lastLine-$firstLine))
@@ -235,7 +235,7 @@ get_log_entries_ts() {
         midLine=$((($lastLine+$firstLine)/2))
         currentLine=`sed "$midLine"!d "$f"`
 
-        # get the timestamp of the line    
+        # get the timestamp of the line
         timestamp=`echo "$currentLine" | awk '{ print $1 }'`
         currentTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
 
@@ -265,7 +265,7 @@ get_log_entries_ts() {
     timestamp=`echo "$currentLine" | awk '{ print $1 }'`
     firstLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`
     diffFirstLineTimestamp=$(($targetTimestamp1970-$firstLineTimestamp1970))
-    
+
     currentLine=`sed "$lastLine"!d "$f"`
     timestamp=`echo "$currentLine" | awk '{ print $1 }'`
     lastLineTimestamp1970=`$BIN_DATE -j -f "$tsFormat" "$timestamp" +"%s" 2>/dev/null`

--- a/common/commonLogFcts.sh
+++ b/common/commonLogFcts.sh
@@ -117,7 +117,7 @@ format_log_txt() {
 
     timestamp=`$BIN_DATE +$tsFormat`
 
-    echo "$timestamp    $criticality    $text"
+    printf "$timestamp\t$criticality\t$text\n"
 
     return 0
 }

--- a/common/commonLogFcts.sh
+++ b/common/commonLogFcts.sh
@@ -215,7 +215,7 @@ get_log_entries_ts() {
         return 1
     fi
 
-    nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`    # find number of lines
+    nbLinesInFile=`wc -l "$f" | awk ' { print $1 } '`  # find number of lines
 
     # if the file does not contain at least 1 line
     if [ "$nbLinesInFile" -lt "1" ]; then

--- a/common/commonMailFcts.sh
+++ b/common/commonMailFcts.sh
@@ -5,8 +5,7 @@
 # Author: fritz from NAS4Free forum
 #
 # Param 1: Subject of the mail
-# Param 2: Content of the mail (Not required if data are provided
-#       from a pipe
+# Param 2: Content of the mail (Not required if data are provided from a pipe)
 ####################################################################
 sendMail() {
     local host subject body line

--- a/common/commonMailFcts.sh
+++ b/common/commonMailFcts.sh
@@ -9,7 +9,7 @@
 ####################################################################
 sendMail() {
     local host subject body line
-    
+
     # Initialize variables
     host=`$BIN_HOSTNAME -s`
     subject="$1"
@@ -25,7 +25,7 @@ sendMail() {
     # if the mail body is NOT provided though the pipe
     else
         body="$2"
-    fi    
+    fi
 
     # Send the mail
     $BIN_PRINTF "From: $CFG_MAIL_FROM\nTo: $CFG_MAIL_TO\nSubject: $subject\n\n$body" | $BIN_MSMTP --file=$CFG_MSMTP_CONF -t

--- a/common/commonMailFcts.sh
+++ b/common/commonMailFcts.sh
@@ -6,31 +6,31 @@
 #
 # Param 1: Subject of the mail
 # Param 2: Content of the mail (Not required if data are provided
-#	   from a pipe
+#       from a pipe
 ####################################################################
 sendMail() {
-	local host subject body line
-	
-	# Initialize variables
-	host=`$BIN_HOSTNAME -s`
-	subject="$1"
-	body=""
+    local host subject body line
+    
+    # Initialize variables
+    host=`$BIN_HOSTNAME -s`
+    subject="$1"
+    body=""
 
-	# If the mail body is provided though the pipe
-	if [ ! -t 0 ]; then
-		local line=""
-		while read line
-		do
-			body="$body\n$line"
-		done
-	# if the mail body is NOT provided though the pipe
-	else
-		body="$2"
-	fi	
+    # If the mail body is provided though the pipe
+    if [ ! -t 0 ]; then
+        local line=""
+        while read line
+        do
+            body="$body\n$line"
+        done
+    # if the mail body is NOT provided though the pipe
+    else
+        body="$2"
+    fi    
 
-	# Send the mail
-	$BIN_PRINTF "From: $CFG_MAIL_FROM\nTo: $CFG_MAIL_TO\nSubject: $subject\n\n$body" | $BIN_MSMTP --file=$CFG_MSMTP_CONF -t
+    # Send the mail
+    $BIN_PRINTF "From: $CFG_MAIL_FROM\nTo: $CFG_MAIL_TO\nSubject: $subject\n\n$body" | $BIN_MSMTP --file=$CFG_MSMTP_CONF -t
 
-	return 0
+    return 0
 }
 

--- a/common/commonSnapFcts.sh
+++ b/common/commonSnapFcts.sh
@@ -6,9 +6,9 @@
 #############################################################################
 
 # Initialisation of constants
-readonly DATE_FORMAT_ZFS="%a %b %d %H:%M %Y"     # format of the snapshot creation date as provided by the 'zfs list -o creation' function
-                        # example: Wed Dec 29 22:59 2010
-readonly DATE_FORMAT_SNAP_NAME="%Y%m%d_%H%M"    # format of the creation date in the snapshot name
+readonly DATE_FORMAT_ZFS="%a %b %d %H:%M %Y"  # format of the snapshot creation date as provided by the 'zfs list -o creation' function
+                                              # example: Wed Dec 29 22:59 2010
+readonly DATE_FORMAT_SNAP_NAME="%Y%m%d_%H%M"  # format of the creation date in the snapshot name
 
 ##################################
 # Return the sorted list of the snaptshots for

--- a/common/commonSnapFcts.sh
+++ b/common/commonSnapFcts.sh
@@ -39,10 +39,10 @@ sortSnapshots() {
 ##################################
 getSnapTimestamp1970() {
     local snapshotName creationDate
-    
+
     snapshotName="$1"
     creationDate=`$BIN_ZFS list -t snapshot -H -o creation "$snapshotName"`
-    
+
     $BIN_DATE -j -f "$DATE_FORMAT_ZFS" "$creationDate" +"%s"
 }
 

--- a/common/commonSnapFcts.sh
+++ b/common/commonSnapFcts.sh
@@ -6,9 +6,9 @@
 #############################################################################
 
 # Initialisation of constants
-readonly DATE_FORMAT_ZFS="%a %b %d %H:%M %Y" 	# format of the snapshot creation date as provided by the 'zfs list -o creation' function
-						# example: Wed Dec 29 22:59 2010
-readonly DATE_FORMAT_SNAP_NAME="%Y%m%d_%H%M"	# format of the creation date in the snapshot name
+readonly DATE_FORMAT_ZFS="%a %b %d %H:%M %Y"     # format of the snapshot creation date as provided by the 'zfs list -o creation' function
+                        # example: Wed Dec 29 22:59 2010
+readonly DATE_FORMAT_SNAP_NAME="%Y%m%d_%H%M"    # format of the creation date in the snapshot name
 
 ##################################
 # Return the sorted list of the snaptshots for
@@ -20,14 +20,14 @@ readonly DATE_FORMAT_SNAP_NAME="%Y%m%d_%H%M"	# format of the creation date in th
 # Return : The sorted list of snapshots
 ##################################
 sortSnapshots() {
-	local filesystem snapshotTag
+    local filesystem snapshotTag
 
-	filesystem="$1"
-	snapshotTag="$2"
+    filesystem="$1"
+    snapshotTag="$2"
 
-	# sort the snapshot based on the "creation" attribute
-	$BIN_ZFS list -H -o name -S creation -t snapshot -d 1 $filesystem \
-		| grep ".*@.*$snapshotTag"
+    # sort the snapshot based on the "creation" attribute
+    $BIN_ZFS list -H -o name -S creation -t snapshot -d 1 $filesystem \
+        | grep ".*@.*$snapshotTag"
 }
 
 ##################################
@@ -38,12 +38,12 @@ sortSnapshots() {
 # Return : creation date in s since 1970
 ##################################
 getSnapTimestamp1970() {
-	local snapshotName creationDate
-	
-	snapshotName="$1"
-	creationDate=`$BIN_ZFS list -t snapshot -H -o creation "$snapshotName"`
-	
-	$BIN_DATE -j -f "$DATE_FORMAT_ZFS" "$creationDate" +"%s"
+    local snapshotName creationDate
+    
+    snapshotName="$1"
+    creationDate=`$BIN_ZFS list -t snapshot -H -o creation "$snapshotName"`
+    
+    $BIN_DATE -j -f "$DATE_FORMAT_ZFS" "$creationDate" +"%s"
 }
 
 ##################################
@@ -57,13 +57,13 @@ getSnapTimestamp1970() {
 # Return : the snapshot name
 ##################################
 generateSnapshotName() {
-	local tag ts tsFormatted
+    local tag ts tsFormatted
 
-	tag="$1"
-	ts="$2"
+    tag="$1"
+    ts="$2"
 
-	tsFormatted=`$BIN_DATE -j -f "%s" "$ts" +"$DATE_FORMAT_SNAP_NAME"`
+    tsFormatted=`$BIN_DATE -j -f "%s" "$ts" +"$DATE_FORMAT_SNAP_NAME"`
 
-	echo "$tsFormatted"_autosnap_"$tag"
+    echo "$tsFormatted"_autosnap_"$tag"
 }
 

--- a/config.sh
+++ b/config.sh
@@ -16,17 +16,17 @@
 # Mail configuration
 ################################################
 
-CFG_MAIL_FROM="nas@example.com"	# Enter the mail address of the NAS here (should be the same address than in NAS GUI: System|Advanced|Email)
-CFG_MAIL_TO="admin@example.com"	# Enter the email of the NAS administrator here
+CFG_MAIL_FROM="nas@example.com"    # Enter the mail address of the NAS here (should be the same address than in NAS GUI: System|Advanced|Email)
+CFG_MAIL_TO="admin@example.com"    # Enter the email of the NAS administrator here
 
 # Paths to log folder, temp folder...
 #
-# ATTENTION: 	THESE FOLDERS MUST EXIST !!!
-# 		IF THEY DON'T, PLEASE CREATE THEM
+# ATTENTION: THESE FOLDERS MUST EXIST !!!
+#            IF THEY DON'T, PLEASE CREATE THEM
 ################################################
 
-CFG_TMP_FOLDER="./tmp"		# Folder used to write temporary file
-CFG_LOG_FOLDER="./log"		# Folder containing all log files
+CFG_TMP_FOLDER="./tmp"        # Folder used to write temporary file
+CFG_LOG_FOLDER="./log"        # Folder containing all log files
 
 
 
@@ -43,8 +43,8 @@ CFG_VERSION="v2.4"
 # Paths to specific temp files / folders ...
 ################################################
 
-CFG_LOCKS_FOLDER="$CFG_TMP_FOLDER/locks"					# Folder containing all locks (indicating that a script is running)
-CFG_FORBID_ANY_LOCK_ACQUISITION_FILE="$CFG_TMP_FOLDER/forbid_acquisition.lock"	# File aimed at notifying that no lock is allowed to be acquired
+CFG_LOCKS_FOLDER="$CFG_TMP_FOLDER/locks"                    # Folder containing all locks (indicating that a script is running)
+CFG_FORBID_ANY_LOCK_ACQUISITION_FILE="$CFG_TMP_FOLDER/forbid_acquisition.lock"    # File aimed at notifying that no lock is allowed to be acquired
 
 # Path to used utilities
 ################################################

--- a/config.sh
+++ b/config.sh
@@ -16,8 +16,8 @@
 # Mail configuration
 ################################################
 
-CFG_MAIL_FROM="nas@example.com"    # Enter the mail address of the NAS here (should be the same address than in NAS GUI: System|Advanced|Email)
-CFG_MAIL_TO="admin@example.com"    # Enter the email of the NAS administrator here
+CFG_MAIL_FROM="nas@example.com"  # Enter the mail address of the NAS here (should be the same address than in NAS GUI: System|Advanced|Email)
+CFG_MAIL_TO="admin@example.com"  # Enter the email of the NAS administrator here
 
 # Paths to log folder, temp folder...
 #
@@ -25,8 +25,8 @@ CFG_MAIL_TO="admin@example.com"    # Enter the email of the NAS administrator he
 #            IF THEY DON'T, PLEASE CREATE THEM
 ################################################
 
-CFG_TMP_FOLDER="./tmp"        # Folder used to write temporary file
-CFG_LOG_FOLDER="./log"        # Folder containing all log files
+CFG_TMP_FOLDER="./tmp"  # Folder used to write temporary file
+CFG_LOG_FOLDER="./log"  # Folder containing all log files
 
 
 
@@ -43,8 +43,8 @@ CFG_VERSION="v2.4"
 # Paths to specific temp files / folders ...
 ################################################
 
-CFG_LOCKS_FOLDER="$CFG_TMP_FOLDER/locks"                    # Folder containing all locks (indicating that a script is running)
-CFG_FORBID_ANY_LOCK_ACQUISITION_FILE="$CFG_TMP_FOLDER/forbid_acquisition.lock"    # File aimed at notifying that no lock is allowed to be acquired
+CFG_LOCKS_FOLDER="$CFG_TMP_FOLDER/locks"  # Folder containing all locks (indicating that a script is running)
+CFG_FORBID_ANY_LOCK_ACQUISITION_FILE="$CFG_TMP_FOLDER/forbid_acquisition.lock"  # File aimed at notifying that no lock is allowed to be acquired
 
 # Path to used utilities
 ################################################

--- a/manageAcpi.sh
+++ b/manageAcpi.sh
@@ -11,37 +11,37 @@
 #
 # Usage: manageAcpi.sh [-p duration] [-w duration] [-a beg,end] [-s delay] [-c beg,end,acpi] [-n ips,delay,acpi] [-vm]
 #
-#	- p duration :		Define the duration (in seconds) between each respective poll (by default: 120)
-#	- w duration :		Define the duration (in seconds) for which the NAS should never sleep after
-#				it wakes up (by default: 600)
-#	- a beg,end :		Define a timeslot in which the NAS shall never go sleeping (e.g. because admin
-#				tasks are scheduled during this slot)
-#				(This option superseeds a sleep order originating from -c and -n)
-#				+ beg: time of the beginning of the slot (format: hh:mm)
-#				+ end: time of the end of the slot (format: hh:mm)
-#	- s delay :		Define that the NAS shall never go sleep if an incoming SSH connection exists.
-#				This function may be required in case the NAS is used as a destination of a remote
-#				backup.
-#				(This option superseeds a sleep order originating from -c and -n)
-#				+ delay: delay in seconds between the end of the connection and start of sleep
-#	- c beg,end,acpi :	Define a curfew timeslot in which the NAS shall go sleeping.
-#				+ beg: time of the beginning of the slot (format: hh:mm)
-#				+ end: time of the end of the slot (format: hh:mm)
-#				+ acpi: the ACPI state selected for the sleep (3 or 5)
-#	- n ips,delay,acpi : 	Define that the NAS shall sleep if none of the other devices are online
-#				+ ips: IP addresses of the devices to poll (at least one), separated by "+" (Note: IP shall be static)
-#				+ delay: delay in seconds between last device going offline and start of sleep
-#				+ acpi: the ACPI state selected for the sleep (3 or 5)
-#	- v:			Requests the log to be more verbose
-#				Note: This is likely to prevent the disks to spin down
-#	- m:			Send mail on ACPI state change
+#    - p duration :        Define the duration (in seconds) between each respective poll (by default: 120)
+#    - w duration :        Define the duration (in seconds) for which the NAS should never sleep after
+#                it wakes up (by default: 600)
+#    - a beg,end :        Define a timeslot in which the NAS shall never go sleeping (e.g. because admin
+#                tasks are scheduled during this slot)
+#                (This option superseeds a sleep order originating from -c and -n)
+#                + beg: time of the beginning of the slot (format: hh:mm)
+#                + end: time of the end of the slot (format: hh:mm)
+#    - s delay :        Define that the NAS shall never go sleep if an incoming SSH connection exists.
+#                This function may be required in case the NAS is used as a destination of a remote
+#                backup.
+#                (This option superseeds a sleep order originating from -c and -n)
+#                + delay: delay in seconds between the end of the connection and start of sleep
+#    - c beg,end,acpi :    Define a curfew timeslot in which the NAS shall go sleeping.
+#                + beg: time of the beginning of the slot (format: hh:mm)
+#                + end: time of the end of the slot (format: hh:mm)
+#                + acpi: the ACPI state selected for the sleep (3 or 5)
+#    - n ips,delay,acpi :     Define that the NAS shall sleep if none of the other devices are online
+#                + ips: IP addresses of the devices to poll (at least one), separated by "+" (Note: IP shall be static)
+#                + delay: delay in seconds between last device going offline and start of sleep
+#                + acpi: the ACPI state selected for the sleep (3 or 5)
+#    - v:            Requests the log to be more verbose
+#                Note: This is likely to prevent the disks to spin down
+#    - m:            Send mail on ACPI state change
 #
 # Author: fritz from NAS4Free forum
 #
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -68,29 +68,29 @@ I_VERBOSE=0
 I_MAIL_ACPI_CHANGE=0
 
 # Initialisation of the default values for the arguments of the script
-I_POLL_INTERVAL=120			# number of seconds to wait between to cycles
+I_POLL_INTERVAL=120            # number of seconds to wait between to cycles
 
-I_DELAY_PREVENT_SLEEP_AFTER_WAKE="600"	# Amount of time during which the NAS will never go to sleep after waking up
+I_DELAY_PREVENT_SLEEP_AFTER_WAKE="600"    # Amount of time during which the NAS will never go to sleep after waking up
 
-I_CHECK_ALWAYS_ON="0"			# 1 if the check shall be performed, 0 otherwise
-I_BEG_ALWAYS_ON="00:00"			# time when the NAS shall never sleep (because of management tasks like backup may start)
-I_END_ALWAYS_ON="00:00"			# If end = beg => 24 hours
+I_CHECK_ALWAYS_ON="0"            # 1 if the check shall be performed, 0 otherwise
+I_BEG_ALWAYS_ON="00:00"            # time when the NAS shall never sleep (because of management tasks like backup may start)
+I_END_ALWAYS_ON="00:00"            # If end = beg => 24 hours
 
-I_CHECK_SSH_ACTIVE="0"			# 1 if the check shall be performed, 0 otherwise
-I_DELAY_SSH="0"				# Delay in seconds between the moment where the SSH connection stops and the moment where the NAS may sleep
+I_CHECK_SSH_ACTIVE="0"            # 1 if the check shall be performed, 0 otherwise
+I_DELAY_SSH="0"                # Delay in seconds between the moment where the SSH connection stops and the moment where the NAS may sleep
 
-I_CHECK_CURFEW_ACTIVE="0"		# 1 if the check shall be performed, 0 otherwise
-I_BEG_POLL_CURFEW="00:00"		# time when the script enters the sleep state (except if tasks like backup are running)
-I_END_POLL_CURFEW="00:00"		# If end = beg => 24 hours
-I_ACPI_STATE_CURFEW="0"			# ACPI state
+I_CHECK_CURFEW_ACTIVE="0"        # 1 if the check shall be performed, 0 otherwise
+I_BEG_POLL_CURFEW="00:00"        # time when the script enters the sleep state (except if tasks like backup are running)
+I_END_POLL_CURFEW="00:00"        # If end = beg => 24 hours
+I_ACPI_STATE_CURFEW="0"            # ACPI state
 
-I_CHECK_NOONLINE_ACTIVE="0"		# 1 if the check shall be performed, 0 otherwise
-I_IP_ADDRS="" 				# IP addresses of the devices to be polled, separated by a space character)
-I_DELAY_NOONLINE="0"			# Delay in seconds between the moment where no devices are online anymore and the moment where the NAS shall sleep
-I_ACPI_STATE_NOONLINE="0"		# ACPI state if no other device is online
+I_CHECK_NOONLINE_ACTIVE="0"        # 1 if the check shall be performed, 0 otherwise
+I_IP_ADDRS=""                 # IP addresses of the devices to be polled, separated by a space character)
+I_DELAY_NOONLINE="0"            # Delay in seconds between the moment where no devices are online anymore and the moment where the NAS shall sleep
+I_ACPI_STATE_NOONLINE="0"        # ACPI state if no other device is online
 
 # Initialization the global variables
-awake="0"				# 1=NAS is awake, 0=NAS is about to sleep (resp. just woke up)
+awake="0"                # 1=NAS is awake, 0=NAS is about to sleep (resp. just woke up)
 
 
 ##################################
@@ -101,104 +101,104 @@ awake="0"				# 1=NAS is awake, 0=NAS is about to sleep (resp. just woke up)
 ##################################
 parseInputParams() {
 
-	local regex_dur regex_hh regex_mm regex_time regex_0_255 regex_ip regex_a regex_c regex_n opt w_min
+    local regex_dur regex_hh regex_mm regex_time regex_0_255 regex_ip regex_a regex_c regex_n opt w_min
 
-	regex_dur="([0-9]+)"
-	regex_hh="(([0-9])|([0-1][0-9])|([2][0-3]))"
-	regex_mm="([0-5][0-9])"
-	regex_time="($regex_hh[:]$regex_mm)"
-	regex_0_255="(([0-9])|([1-9][0-9])|([1][0-9][0-9])|([2][0-4][0-9])|([2][5][0-5]))"
-	regex_ip="(($regex_0_255[.]){3,3}$regex_0_255)"
+    regex_dur="([0-9]+)"
+    regex_hh="(([0-9])|([0-1][0-9])|([2][0-3]))"
+    regex_mm="([0-5][0-9])"
+    regex_time="($regex_hh[:]$regex_mm)"
+    regex_0_255="(([0-9])|([1-9][0-9])|([1][0-9][0-9])|([2][0-4][0-9])|([2][5][0-5]))"
+    regex_ip="(($regex_0_255[.]){3,3}$regex_0_255)"
 
-	regex_a="^$regex_time[,]$regex_time$"
-	regex_c="^($regex_time[,]){2,2}[35]$"
-	regex_n="^$regex_ip([+]$regex_ip){0,}[,]$regex_dur[,][35]$"
+    regex_a="^$regex_time[,]$regex_time$"
+    regex_c="^($regex_time[,]){2,2}[35]$"
+    regex_n="^$regex_ip([+]$regex_ip){0,}[,]$regex_dur[,][35]$"
 
-	w_min="300"
+    w_min="300"
 
-	# parse the parameters
-	while getopts ":p:w:a:s:c:n:vm" opt; do
-		
-		case $opt in
-			p)	echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_POLL_INTERVAL="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -p. Should be a positive integer"
-					return 1
-				fi ;;
-			w)	echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$OPTARG"
+    # parse the parameters
+    while getopts ":p:w:a:s:c:n:vm" opt; do
+        
+        case $opt in
+            p)    echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_POLL_INTERVAL="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -p. Should be a positive integer"
+                    return 1
+                fi ;;
+            w)    echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$OPTARG"
 
-					if [ "$I_DELAY_PREVENT_SLEEP_AFTER_WAKE" -lt "$w_min" ] ; then
-						echo "The value passed to the -w option must be at least $w_min s."
-						echo "Replacing the provided value ($I_DELAY_PREVENT_SLEEP_AFTER_WAKE s) with the value $w_min s"
-						echo "Rationale: If other options are not set correctly, the server may always"
-						echo "shutdown/sleep just after booting making the server unusable"
-						I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$w_min"			
-					fi
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -w. Should be a positive integer"
-					return 1
-				fi ;;
-			a)	echo "$OPTARG" | grep -E "$regex_a" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_CHECK_ALWAYS_ON="1"	
-					I_BEG_ALWAYS_ON=`echo "$OPTARG" | cut -f1 -d,`
-					I_END_ALWAYS_ON=`echo "$OPTARG" | cut -f2 -d,`
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -a. Should be \"hh:mm,hh:mm\""
-					return 1
-				fi ;;
-			s)	echo "$OPTARG" | grep -E "$regex_dur" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_CHECK_SSH_ACTIVE="1"			
-					I_DELAY_SSH="$OPTARG"
-				else
-					echo "$LOGFILE" "Invalid parameter \"$OPTARG\" for option: -s. Should be a positive integer"
-					return 1
-				fi ;;
-			c)	echo "$OPTARG" | grep -E "$regex_c" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_CHECK_CURFEW_ACTIVE="1"	
-					I_BEG_POLL_CURFEW=`echo "$OPTARG" | cut -f1 -d,`			
-					I_END_POLL_CURFEW=`echo "$OPTARG" | cut -f2 -d,`			
-					I_ACPI_STATE_CURFEW=`echo "$OPTARG" | cut -f3 -d,`			
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -c. Should be \"hh:mm,hh:mm,acpi_state\""
-					return 1
-				fi ;;
-			n)	echo "$OPTARG" | grep -E "$regex_n" >/dev/null
-				if [ "$?" -eq "0" ] ; then
-					I_CHECK_NOONLINE_ACTIVE="1"
-					I_IP_ADDRS=`echo "$OPTARG" | cut -f1 -d, | sed 's/+/ /g'`
-					I_DELAY_NOONLINE=`echo "$OPTARG" | cut -f2 -d,`
-					I_ACPI_STATE_NOONLINE=`echo "$OPTARG" | cut -f3 -d,`
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -n. Should be \"ips,delay,acpi_state\""
-					return 1
-				fi ;;
-			v)	I_VERBOSE=1 ;;
-			m)	I_MAIL_ACPI_CHANGE=1 ;;
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-                        :)
-				echo "Option -$OPTARG requires an argument"
-				return 1 ;;
+                    if [ "$I_DELAY_PREVENT_SLEEP_AFTER_WAKE" -lt "$w_min" ] ; then
+                        echo "The value passed to the -w option must be at least $w_min s."
+                        echo "Replacing the provided value ($I_DELAY_PREVENT_SLEEP_AFTER_WAKE s) with the value $w_min s"
+                        echo "Rationale: If other options are not set correctly, the server may always"
+                        echo "shutdown/sleep just after booting making the server unusable"
+                        I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$w_min"            
+                    fi
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -w. Should be a positive integer"
+                    return 1
+                fi ;;
+            a)    echo "$OPTARG" | grep -E "$regex_a" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_CHECK_ALWAYS_ON="1"    
+                    I_BEG_ALWAYS_ON=`echo "$OPTARG" | cut -f1 -d,`
+                    I_END_ALWAYS_ON=`echo "$OPTARG" | cut -f2 -d,`
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -a. Should be \"hh:mm,hh:mm\""
+                    return 1
+                fi ;;
+            s)    echo "$OPTARG" | grep -E "$regex_dur" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_CHECK_SSH_ACTIVE="1"            
+                    I_DELAY_SSH="$OPTARG"
+                else
+                    echo "$LOGFILE" "Invalid parameter \"$OPTARG\" for option: -s. Should be a positive integer"
+                    return 1
+                fi ;;
+            c)    echo "$OPTARG" | grep -E "$regex_c" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_CHECK_CURFEW_ACTIVE="1"    
+                    I_BEG_POLL_CURFEW=`echo "$OPTARG" | cut -f1 -d,`            
+                    I_END_POLL_CURFEW=`echo "$OPTARG" | cut -f2 -d,`            
+                    I_ACPI_STATE_CURFEW=`echo "$OPTARG" | cut -f3 -d,`            
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -c. Should be \"hh:mm,hh:mm,acpi_state\""
+                    return 1
+                fi ;;
+            n)    echo "$OPTARG" | grep -E "$regex_n" >/dev/null
+                if [ "$?" -eq "0" ] ; then
+                    I_CHECK_NOONLINE_ACTIVE="1"
+                    I_IP_ADDRS=`echo "$OPTARG" | cut -f1 -d, | sed 's/+/ /g'`
+                    I_DELAY_NOONLINE=`echo "$OPTARG" | cut -f2 -d,`
+                    I_ACPI_STATE_NOONLINE=`echo "$OPTARG" | cut -f3 -d,`
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -n. Should be \"ips,delay,acpi_state\""
+                    return 1
+                fi ;;
+            v)    I_VERBOSE=1 ;;
+            m)    I_MAIL_ACPI_CHANGE=1 ;;
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            :)
+                echo "Option -$OPTARG requires an argument"
+                return 1 ;;
                 esac
         done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "0" ]; then
-		echo "No mandatory arguments should be provided"
-		return 1
-	fi
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "0" ]; then
+        echo "No mandatory arguments should be provided"
+        return 1
+    fi
 
         return 0
 }
@@ -210,34 +210,34 @@ parseInputParams() {
 #
 # Param 1: Start of the timeslot (format: "hh:mm")
 # Param 2: End of the timeslot (format: "hh:mm"). If End=Beg,
-#	   the timeslot is considered to last the whole day.
+#       the timeslot is considered to last the whole day.
 # Return: 0 if the current time is within the timeslot
 ##################################
 isInTimeSlot() {
-	local startTime endTime nbSecInDay currentTimestamp startTimestamp endTimestamp
+    local startTime endTime nbSecInDay currentTimestamp startTimestamp endTimestamp
 
-	startTime="$1"
+    startTime="$1"
         endTime="$2"
 
-	nbSecInDay="86400"
+    nbSecInDay="86400"
 
-	currentTimestamp=`$BIN_DATE +"%s"`
-	startTimestamp=`$BIN_DATE -j -f "%H:%M:%S" "$startTime:00" +"%s"`
-	endTimestamp=`$BIN_DATE -j -f "%H:%M:%S" "$endTime:00" +"%s"`
+    currentTimestamp=`$BIN_DATE +"%s"`
+    startTimestamp=`$BIN_DATE -j -f "%H:%M:%S" "$startTime:00" +"%s"`
+    endTimestamp=`$BIN_DATE -j -f "%H:%M:%S" "$endTime:00" +"%s"`
 
-	if [ "$endTimestamp" -le "$startTimestamp" ]; then
-		if [ "$currentTimestamp" -gt "$startTimestamp" ]; then
-			endTimestamp=`expr $endTimestamp + $nbSecInDay`
-		else
-			startTimestamp=`expr $startTimestamp - $nbSecInDay`
-		fi
-	fi
+    if [ "$endTimestamp" -le "$startTimestamp" ]; then
+        if [ "$currentTimestamp" -gt "$startTimestamp" ]; then
+            endTimestamp=`expr $endTimestamp + $nbSecInDay`
+        else
+            startTimestamp=`expr $startTimestamp - $nbSecInDay`
+        fi
+    fi
 
-	if [ "$currentTimestamp" -gt "$startTimestamp" -a "$currentTimestamp" -le "$endTimestamp" ]; then
-		return 0
-	else
-		return 1
-	fi
+    if [ "$currentTimestamp" -gt "$startTimestamp" -a "$currentTimestamp" -le "$endTimestamp" ]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 
@@ -250,46 +250,46 @@ isInTimeSlot() {
 # Return: 0 if the the NAS could be shutdown
 ##################################
 nasSleep() {
-	local acpi_state msg
+    local acpi_state msg
 
-	acpi_state="$1"
+    acpi_state="$1"
 
         if ! does_any_lock_exist; then
 
                 msg="Shutting down the system to save energy (ACPI state : S$acpi_state)"
 
-		if [ $acpi_state -eq "5" ]; then	# Soft OFF
+        if [ $acpi_state -eq "5" ]; then    # Soft OFF
 
-			log_info "$LOGFILE" "$msg"
-			log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
-        	
-			if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then	
-				get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
-			fi
+            log_info "$LOGFILE" "$msg"
+            log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
+            
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+                get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
+            fi
 
-			awake="0"
-			$BIN_SHUTDOWN -p now "$msg"
-	
-		elif [ $acpi_state -eq "3" ]; then	# Suspend to RAM
-	        	
-			log_info "$LOGFILE" "$msg"
-			log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
+            awake="0"
+            $BIN_SHUTDOWN -p now "$msg"
+    
+        elif [ $acpi_state -eq "3" ]; then    # Suspend to RAM
+                
+            log_info "$LOGFILE" "$msg"
+            log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
 
-			if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then	
-				get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
-			fi		
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+                get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
+            fi        
 
-			awake="0"
-			$BIN_ACPICONF -s 3	
-		else
-			log_error "$LOGFILE" "Shutdown not possible. ACPI state \"$acpi_state\" not supported"
-			return 1
-		fi	
-		return 0
-	else
-		log_info "$LOGFILE" "Shutdown not possible. The following scripts are running: `get_list_of_locks`"
-		return 1
-	fi
+            awake="0"
+            $BIN_ACPICONF -s 3    
+        else
+            log_error "$LOGFILE" "Shutdown not possible. ACPI state \"$acpi_state\" not supported"
+            return 1
+        fi    
+        return 0
+    else
+        log_info "$LOGFILE" "Shutdown not possible. The following scripts are running: `get_list_of_locks`"
+        return 1
+    fi
 }
 
 
@@ -299,159 +299,159 @@ nasSleep() {
 # Main
 ##################################
 main() {
-	local ts_last_online_device ts_last_ssh ts_wakeup in_always_on_timeslot curfew_sleep_request \
-		noonline_sleep_request any_device_online delta_t awakefor
-	
-	# initialization of local variables
-	ts_last_online_device=`$BIN_DATE +%s`	# Timestamp when the last other device was detected to be online
-	ts_last_ssh=`$BIN_DATE +%s`		# Timestamp when the last SSH connection ended
-	ts_wakeup=`$BIN_DATE +%s`		# Timestamp when the NAS woke up last time
-	in_always_on_timeslot="0"		# 1=We are currently in the always on timeslot, 0 otherwise
-	ssh_sleep_prevent="0"			# 1=Sleep prevented by SSH, 0 otherwise
-	curfew_sleep_request="0"		# 1=Sleep requested by curfew check, 0 otherwise
-	noonline_sleep_request="0"		# 1=Sleep requested by no-online check, 0 otherwise
+    local ts_last_online_device ts_last_ssh ts_wakeup in_always_on_timeslot curfew_sleep_request \
+        noonline_sleep_request any_device_online delta_t awakefor
+    
+    # initialization of local variables
+    ts_last_online_device=`$BIN_DATE +%s`    # Timestamp when the last other device was detected to be online
+    ts_last_ssh=`$BIN_DATE +%s`        # Timestamp when the last SSH connection ended
+    ts_wakeup=`$BIN_DATE +%s`        # Timestamp when the NAS woke up last time
+    in_always_on_timeslot="0"        # 1=We are currently in the always on timeslot, 0 otherwise
+    ssh_sleep_prevent="0"            # 1=Sleep prevented by SSH, 0 otherwise
+    curfew_sleep_request="0"        # 1=Sleep requested by curfew check, 0 otherwise
+    noonline_sleep_request="0"        # 1=Sleep requested by no-online check, 0 otherwise
 
-	# Remove any existing lock
-	reset_locks
+    # Remove any existing lock
+    reset_locks
 
-	# log the selected configuration
-	log_info "$LOGFILE" "Selected settings for \"$SCRIPT_NAME\":"
-	printf '%-35s %s\n' "- VERBOSE:" "$I_VERBOSE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- MAIL ACPI STATE CHANGES:" "$I_MAIL_ACPI_CHANGE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- POLL_INTERVAL:" "$I_POLL_INTERVAL" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- DELAY_PREVENT_SLEEP_AFTER_WAKE:" "$I_DELAY_PREVENT_SLEEP_AFTER_WAKE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- CHECK_ALWAYS_ON:" "$I_CHECK_ALWAYS_ON" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- BEG_ALWAYS_ON:" "$I_BEG_ALWAYS_ON" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- END_ALWAYS_ON:" "$I_END_ALWAYS_ON" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- CHECK_SSH_ACTIVE:" "$I_CHECK_SSH_ACTIVE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- DELAY_SSH:" "$I_DELAY_SSH" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- CHECK_CURFEW_ACTIVE:" "$I_CHECK_CURFEW_ACTIVE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- BEG_POLL_CURFEW:" "$I_BEG_POLL_CURFEW" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- END_POLL_CURFEW:" "$I_END_POLL_CURFEW" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- ACPI_STATE_CURFEW:" "$I_ACPI_STATE_CURFEW" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- CHECK_NOONLINE_ACTIVE:" "$I_CHECK_NOONLINE_ACTIVE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- ACPI_STATE_NOONLINE:" "$I_ACPI_STATE_NOONLINE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- DELAY_NOONLINE:" "$I_DELAY_NOONLINE" | log_info "$LOGFILE"
-	printf '%-35s %s\n' "- IP_ADDRS:" "$I_IP_ADDRS" | log_info "$LOGFILE"
+    # log the selected configuration
+    log_info "$LOGFILE" "Selected settings for \"$SCRIPT_NAME\":"
+    printf '%-35s %s\n' "- VERBOSE:" "$I_VERBOSE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- MAIL ACPI STATE CHANGES:" "$I_MAIL_ACPI_CHANGE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- POLL_INTERVAL:" "$I_POLL_INTERVAL" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- DELAY_PREVENT_SLEEP_AFTER_WAKE:" "$I_DELAY_PREVENT_SLEEP_AFTER_WAKE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- CHECK_ALWAYS_ON:" "$I_CHECK_ALWAYS_ON" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- BEG_ALWAYS_ON:" "$I_BEG_ALWAYS_ON" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- END_ALWAYS_ON:" "$I_END_ALWAYS_ON" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- CHECK_SSH_ACTIVE:" "$I_CHECK_SSH_ACTIVE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- DELAY_SSH:" "$I_DELAY_SSH" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- CHECK_CURFEW_ACTIVE:" "$I_CHECK_CURFEW_ACTIVE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- BEG_POLL_CURFEW:" "$I_BEG_POLL_CURFEW" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- END_POLL_CURFEW:" "$I_END_POLL_CURFEW" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- ACPI_STATE_CURFEW:" "$I_ACPI_STATE_CURFEW" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- CHECK_NOONLINE_ACTIVE:" "$I_CHECK_NOONLINE_ACTIVE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- ACPI_STATE_NOONLINE:" "$I_ACPI_STATE_NOONLINE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- DELAY_NOONLINE:" "$I_DELAY_NOONLINE" | log_info "$LOGFILE"
+    printf '%-35s %s\n' "- IP_ADDRS:" "$I_IP_ADDRS" | log_info "$LOGFILE"
 
 
-	# Loop until the NAS is switched off
-	while true; do
-		[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "-----------------"
+    # Loop until the NAS is switched off
+    while true; do
+        [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "-----------------"
 
-		# If the NAS just woke up
-		if [ $awake -eq "0" ]; then
-			awake="1"
- 			ts_wakeup=`$BIN_DATE +%s`       	
-			ts_last_online_device=`$BIN_DATE +%s`
+        # If the NAS just woke up
+        if [ $awake -eq "0" ]; then
+            awake="1"
+             ts_wakeup=`$BIN_DATE +%s`           
+            ts_last_online_device=`$BIN_DATE +%s`
 
-			log_info "$ACPI_STATE_LOGFILE" "S0"
-			log_info "$LOGFILE" "NAS just woke up (S0). Preventing sleep during the next $I_DELAY_PREVENT_SLEEP_AFTER_WAKE s"
+            log_info "$ACPI_STATE_LOGFILE" "S0"
+            log_info "$LOGFILE" "NAS just woke up (S0). Preventing sleep during the next $I_DELAY_PREVENT_SLEEP_AFTER_WAKE s"
 
-			if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then	
-				get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS just woke up (S0)"
-			fi	
-		fi
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+                get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS just woke up (S0)"
+            fi    
+        fi
 
-		# Check if in always_on timeslot
-		in_always_on_timeslot="0"
-		if [ $I_CHECK_ALWAYS_ON -eq "1" ]; then
-			if isInTimeSlot "$I_BEG_ALWAYS_ON" "$I_END_ALWAYS_ON"; then
-				[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "In always_on timeslot: [ $I_BEG_ALWAYS_ON ; $I_END_ALWAYS_ON ]"
-				in_always_on_timeslot="1"
-			fi
-		fi
+        # Check if in always_on timeslot
+        in_always_on_timeslot="0"
+        if [ $I_CHECK_ALWAYS_ON -eq "1" ]; then
+            if isInTimeSlot "$I_BEG_ALWAYS_ON" "$I_END_ALWAYS_ON"; then
+                [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "In always_on timeslot: [ $I_BEG_ALWAYS_ON ; $I_END_ALWAYS_ON ]"
+                in_always_on_timeslot="1"
+            fi
+        fi
 
-		# Check if an incoming SSH connection existed recently
-		ssh_sleep_prevent="0"
-		if [ $I_CHECK_SSH_ACTIVE -eq "1" ]; then
-			# Check if an ingoing ssh connection exist
-			if $BIN_SOCKSTAT -c | grep "sshd" > /dev/null ; then
-				ts_last_ssh=`$BIN_DATE +%s`
-				ssh_sleep_prevent="1"				
-				[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Incoming SSH connection detected"
-			else
-				delta_t=$((`$BIN_DATE +%s`-$ts_last_ssh))
-				[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "No incoming SSH connection for $delta_t s"
-				if [ "$delta_t" -le "$I_DELAY_SSH" ]; then
-					ssh_sleep_prevent="1"
-				fi
-			fi
-		fi
-		
-		# Check if curfew is reached
-		curfew_sleep_request="0"
-		if [ $I_CHECK_CURFEW_ACTIVE -eq "1" ]; then
-			if isInTimeSlot "$I_BEG_POLL_CURFEW" "$I_END_POLL_CURFEW"; then
-				[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "In curfew timeslot: [ $I_BEG_POLL_CURFEW ; $I_END_POLL_CURFEW ]"
-				curfew_sleep_request="1"
-			fi
-		fi
+        # Check if an incoming SSH connection existed recently
+        ssh_sleep_prevent="0"
+        if [ $I_CHECK_SSH_ACTIVE -eq "1" ]; then
+            # Check if an ingoing ssh connection exist
+            if $BIN_SOCKSTAT -c | grep "sshd" > /dev/null ; then
+                ts_last_ssh=`$BIN_DATE +%s`
+                ssh_sleep_prevent="1"                
+                [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Incoming SSH connection detected"
+            else
+                delta_t=$((`$BIN_DATE +%s`-$ts_last_ssh))
+                [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "No incoming SSH connection for $delta_t s"
+                if [ "$delta_t" -le "$I_DELAY_SSH" ]; then
+                    ssh_sleep_prevent="1"
+                fi
+            fi
+        fi
+        
+        # Check if curfew is reached
+        curfew_sleep_request="0"
+        if [ $I_CHECK_CURFEW_ACTIVE -eq "1" ]; then
+            if isInTimeSlot "$I_BEG_POLL_CURFEW" "$I_END_POLL_CURFEW"; then
+                [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "In curfew timeslot: [ $I_BEG_POLL_CURFEW ; $I_END_POLL_CURFEW ]"
+                curfew_sleep_request="1"
+            fi
+        fi
 
-		# Check if no other devices are online for a certain duration
-		noonline_sleep_request="0"	
-		if [ $I_CHECK_NOONLINE_ACTIVE -eq "1" ]; then
-			any_device_online="0"
-			for ip_addr in $I_IP_ADDRS; do 	
-				if $BIN_PING -c 1 -t 1 $ip_addr > /dev/null ; then
-					any_device_online="1"
-					[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Online device detected: $ip_addr (skipping any other device)"
-					break
-				fi
-			done
+        # Check if no other devices are online for a certain duration
+        noonline_sleep_request="0"    
+        if [ $I_CHECK_NOONLINE_ACTIVE -eq "1" ]; then
+            any_device_online="0"
+            for ip_addr in $I_IP_ADDRS; do     
+                if $BIN_PING -c 1 -t 1 $ip_addr > /dev/null ; then
+                    any_device_online="1"
+                    [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Online device detected: $ip_addr (skipping any other device)"
+                    break
+                fi
+            done
 
-			if [ "$any_device_online" -eq "1" ]; then	
-				ts_last_online_device=`$BIN_DATE +%s`
-			else
-				delta_t=$((`$BIN_DATE +%s`-$ts_last_online_device))
-				[ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "No devices online for $delta_t s"
-				if [ "$delta_t" -gt "$I_DELAY_NOONLINE" ]; then
-					noonline_sleep_request="1"	
-				fi
-			fi
-		fi
+            if [ "$any_device_online" -eq "1" ]; then    
+                ts_last_online_device=`$BIN_DATE +%s`
+            else
+                delta_t=$((`$BIN_DATE +%s`-$ts_last_online_device))
+                [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "No devices online for $delta_t s"
+                if [ "$delta_t" -gt "$I_DELAY_NOONLINE" ]; then
+                    noonline_sleep_request="1"    
+                fi
+            fi
+        fi
 
-		# Sleep if requested, but never if:
-		# - The NAS woke-up shortly
-		# - We are in the always on timeslot
-		# - An SSH connection existed recently
-		awakefor=$((`$BIN_DATE +"%s"`-$ts_wakeup))
-		if [ $in_always_on_timeslot -eq "0" -a $ssh_sleep_prevent -eq "0" -a $awakefor -gt $I_DELAY_PREVENT_SLEEP_AFTER_WAKE ]; then
-			if [ $curfew_sleep_request -eq "1" ]; then
-				log_info "$LOGFILE" "Curfew: Sleep requested"
-				prevent_acquire_locks
-				nasSleep $I_ACPI_STATE_CURFEW
- 			elif [ $noonline_sleep_request -eq "1" ]; then
-				log_info "$LOGFILE" "No other device online: sleep requested"
-				prevent_acquire_locks
-				nasSleep $I_ACPI_STATE_NOONLINE
-			else
-				allow_acquire_locks
-			fi
-		else
-			allow_acquire_locks
-		fi
+        # Sleep if requested, but never if:
+        # - The NAS woke-up shortly
+        # - We are in the always on timeslot
+        # - An SSH connection existed recently
+        awakefor=$((`$BIN_DATE +"%s"`-$ts_wakeup))
+        if [ $in_always_on_timeslot -eq "0" -a $ssh_sleep_prevent -eq "0" -a $awakefor -gt $I_DELAY_PREVENT_SLEEP_AFTER_WAKE ]; then
+            if [ $curfew_sleep_request -eq "1" ]; then
+                log_info "$LOGFILE" "Curfew: Sleep requested"
+                prevent_acquire_locks
+                nasSleep $I_ACPI_STATE_CURFEW
+            elif [ $noonline_sleep_request -eq "1" ]; then
+                log_info "$LOGFILE" "No other device online: sleep requested"
+                prevent_acquire_locks
+                nasSleep $I_ACPI_STATE_NOONLINE
+            else
+                allow_acquire_locks
+            fi
+        else
+            allow_acquire_locks
+        fi
 
-		# wait until next poll	
-		sleep $I_POLL_INTERVAL
-	done
+        # wait until next poll    
+        sleep $I_POLL_INTERVAL
+    done
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	$BIN_RM "$TMPFILE_ARGS"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    $BIN_RM "$TMPFILE_ARGS"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	$BIN_RM "$TMPFILE_ARGS"
-	log_info "$LOGFILE" "-------------------------------------"
-	
+    $BIN_RM "$TMPFILE_ARGS"
+    log_info "$LOGFILE" "-------------------------------------"
+    
         # Return the log entries that have been logged during the current
         # execution of the script
-	! main && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "Sleep management issue"
+    ! main && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "Sleep management issue"
 fi
 
 exit 0

--- a/manageAcpi.sh
+++ b/manageAcpi.sh
@@ -41,7 +41,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -68,29 +68,29 @@ I_VERBOSE=0
 I_MAIL_ACPI_CHANGE=0
 
 # Initialisation of the default values for the arguments of the script
-I_POLL_INTERVAL=120            # number of seconds to wait between to cycles
+I_POLL_INTERVAL=120  # number of seconds to wait between to cycles
 
-I_DELAY_PREVENT_SLEEP_AFTER_WAKE="600"    # Amount of time during which the NAS will never go to sleep after waking up
+I_DELAY_PREVENT_SLEEP_AFTER_WAKE="600"  # Amount of time during which the NAS will never go to sleep after waking up
 
-I_CHECK_ALWAYS_ON="0"            # 1 if the check shall be performed, 0 otherwise
-I_BEG_ALWAYS_ON="00:00"            # time when the NAS shall never sleep (because of management tasks like backup may start)
-I_END_ALWAYS_ON="00:00"            # If end = beg => 24 hours
+I_CHECK_ALWAYS_ON="0"  # 1 if the check shall be performed, 0 otherwise
+I_BEG_ALWAYS_ON="00:00"  # time when the NAS shall never sleep (because of management tasks like backup may start)
+I_END_ALWAYS_ON="00:00"  # If end = beg => 24 hours
 
-I_CHECK_SSH_ACTIVE="0"            # 1 if the check shall be performed, 0 otherwise
-I_DELAY_SSH="0"                # Delay in seconds between the moment where the SSH connection stops and the moment where the NAS may sleep
+I_CHECK_SSH_ACTIVE="0"  # 1 if the check shall be performed, 0 otherwise
+I_DELAY_SSH="0"  # Delay in seconds between the moment where the SSH connection stops and the moment where the NAS may sleep
 
-I_CHECK_CURFEW_ACTIVE="0"        # 1 if the check shall be performed, 0 otherwise
-I_BEG_POLL_CURFEW="00:00"        # time when the script enters the sleep state (except if tasks like backup are running)
-I_END_POLL_CURFEW="00:00"        # If end = beg => 24 hours
-I_ACPI_STATE_CURFEW="0"            # ACPI state
+I_CHECK_CURFEW_ACTIVE="0"  # 1 if the check shall be performed, 0 otherwise
+I_BEG_POLL_CURFEW="00:00"  # time when the script enters the sleep state (except if tasks like backup are running)
+I_END_POLL_CURFEW="00:00"  # If end = beg => 24 hours
+I_ACPI_STATE_CURFEW="0"  # ACPI state
 
-I_CHECK_NOONLINE_ACTIVE="0"        # 1 if the check shall be performed, 0 otherwise
-I_IP_ADDRS=""                 # IP addresses of the devices to be polled, separated by a space character)
-I_DELAY_NOONLINE="0"            # Delay in seconds between the moment where no devices are online anymore and the moment where the NAS shall sleep
-I_ACPI_STATE_NOONLINE="0"        # ACPI state if no other device is online
+I_CHECK_NOONLINE_ACTIVE="0"  # 1 if the check shall be performed, 0 otherwise
+I_IP_ADDRS=""  # IP addresses of the devices to be polled, separated by a space character)
+I_DELAY_NOONLINE="0"  # Delay in seconds between the moment where no devices are online anymore and the moment where the NAS shall sleep
+I_ACPI_STATE_NOONLINE="0"  # ACPI state if no other device is online
 
 # Initialization the global variables
-awake="0"                # 1=NAS is awake, 0=NAS is about to sleep (resp. just woke up)
+awake="0"  # 1=NAS is awake, 0=NAS is about to sleep (resp. just woke up)
 
 
 ##################################
@@ -258,7 +258,7 @@ nasSleep() {
 
                 msg="Shutting down the system to save energy (ACPI state : S$acpi_state)"
 
-        if [ $acpi_state -eq "5" ]; then    # Soft OFF
+        if [ $acpi_state -eq "5" ]; then  # Soft OFF
 
             log_info "$LOGFILE" "$msg"
             log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
@@ -270,7 +270,7 @@ nasSleep() {
             awake="0"
             $BIN_SHUTDOWN -p now "$msg"
 
-        elif [ $acpi_state -eq "3" ]; then    # Suspend to RAM
+        elif [ $acpi_state -eq "3" ]; then  # Suspend to RAM
 
             log_info "$LOGFILE" "$msg"
             log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
@@ -303,13 +303,13 @@ main() {
         noonline_sleep_request any_device_online delta_t awakefor
 
     # initialization of local variables
-    ts_last_online_device=`$BIN_DATE +%s`    # Timestamp when the last other device was detected to be online
-    ts_last_ssh=`$BIN_DATE +%s`        # Timestamp when the last SSH connection ended
-    ts_wakeup=`$BIN_DATE +%s`        # Timestamp when the NAS woke up last time
-    in_always_on_timeslot="0"        # 1=We are currently in the always on timeslot, 0 otherwise
-    ssh_sleep_prevent="0"            # 1=Sleep prevented by SSH, 0 otherwise
-    curfew_sleep_request="0"        # 1=Sleep requested by curfew check, 0 otherwise
-    noonline_sleep_request="0"        # 1=Sleep requested by no-online check, 0 otherwise
+    ts_last_online_device=`$BIN_DATE +%s`  # Timestamp when the last other device was detected to be online
+    ts_last_ssh=`$BIN_DATE +%s`  # Timestamp when the last SSH connection ended
+    ts_wakeup=`$BIN_DATE +%s`  # Timestamp when the NAS woke up last time
+    in_always_on_timeslot="0"  # 1=We are currently in the always on timeslot, 0 otherwise
+    ssh_sleep_prevent="0"  # 1=Sleep prevented by SSH, 0 otherwise
+    curfew_sleep_request="0"  # 1=Sleep requested by curfew check, 0 otherwise
+    noonline_sleep_request="0"  # 1=Sleep requested by no-online check, 0 otherwise
 
     # Remove any existing lock
     reset_locks

--- a/manageAcpi.sh
+++ b/manageAcpi.sh
@@ -118,7 +118,7 @@ parseInputParams() {
 
     # parse the parameters
     while getopts ":p:w:a:s:c:n:vm" opt; do
-        
+
         case $opt in
             p) echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
@@ -136,7 +136,7 @@ parseInputParams() {
                         echo "Replacing the provided value ($I_DELAY_PREVENT_SLEEP_AFTER_WAKE s) with the value $w_min s"
                         echo "Rationale: If other options are not set correctly, the server may always"
                         echo "shutdown/sleep just after booting making the server unusable"
-                        I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$w_min"            
+                        I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$w_min"
                     fi
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -w. Should be a positive integer"
@@ -144,7 +144,7 @@ parseInputParams() {
                 fi ;;
             a) echo "$OPTARG" | grep -E "$regex_a" >/dev/null
                 if [ "$?" -eq "0" ] ; then
-                    I_CHECK_ALWAYS_ON="1"    
+                    I_CHECK_ALWAYS_ON="1"
                     I_BEG_ALWAYS_ON=`echo "$OPTARG" | cut -f1 -d,`
                     I_END_ALWAYS_ON=`echo "$OPTARG" | cut -f2 -d,`
                 else
@@ -153,7 +153,7 @@ parseInputParams() {
                 fi ;;
             s) echo "$OPTARG" | grep -E "$regex_dur" >/dev/null
                 if [ "$?" -eq "0" ] ; then
-                    I_CHECK_SSH_ACTIVE="1"            
+                    I_CHECK_SSH_ACTIVE="1"
                     I_DELAY_SSH="$OPTARG"
                 else
                     echo "$LOGFILE" "Invalid parameter \"$OPTARG\" for option: -s. Should be a positive integer"
@@ -161,10 +161,10 @@ parseInputParams() {
                 fi ;;
             c) echo "$OPTARG" | grep -E "$regex_c" >/dev/null
                 if [ "$?" -eq "0" ] ; then
-                    I_CHECK_CURFEW_ACTIVE="1"    
-                    I_BEG_POLL_CURFEW=`echo "$OPTARG" | cut -f1 -d,`            
-                    I_END_POLL_CURFEW=`echo "$OPTARG" | cut -f2 -d,`            
-                    I_ACPI_STATE_CURFEW=`echo "$OPTARG" | cut -f3 -d,`            
+                    I_CHECK_CURFEW_ACTIVE="1"
+                    I_BEG_POLL_CURFEW=`echo "$OPTARG" | cut -f1 -d,`
+                    I_END_POLL_CURFEW=`echo "$OPTARG" | cut -f2 -d,`
+                    I_ACPI_STATE_CURFEW=`echo "$OPTARG" | cut -f3 -d,`
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -c. Should be \"hh:mm,hh:mm,acpi_state\""
                     return 1
@@ -192,7 +192,7 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "0" ]; then
@@ -262,29 +262,29 @@ nasSleep() {
 
             log_info "$LOGFILE" "$msg"
             log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
-            
-            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then
                 get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
             fi
 
             awake="0"
             $BIN_SHUTDOWN -p now "$msg"
-    
+
         elif [ $acpi_state -eq "3" ]; then    # Suspend to RAM
-                
+
             log_info "$LOGFILE" "$msg"
             log_info "$ACPI_STATE_LOGFILE" "S$acpi_state"
 
-            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then
                 get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS going to sleep to save energy (ACPI state: S$acpi_state)"
-            fi        
+            fi
 
             awake="0"
-            $BIN_ACPICONF -s 3    
+            $BIN_ACPICONF -s 3
         else
             log_error "$LOGFILE" "Shutdown not possible. ACPI state \"$acpi_state\" not supported"
             return 1
-        fi    
+        fi
         return 0
     else
         log_info "$LOGFILE" "Shutdown not possible. The following scripts are running: `get_list_of_locks`"
@@ -301,7 +301,7 @@ nasSleep() {
 main() {
     local ts_last_online_device ts_last_ssh ts_wakeup in_always_on_timeslot curfew_sleep_request \
         noonline_sleep_request any_device_online delta_t awakefor
-    
+
     # initialization of local variables
     ts_last_online_device=`$BIN_DATE +%s`    # Timestamp when the last other device was detected to be online
     ts_last_ssh=`$BIN_DATE +%s`        # Timestamp when the last SSH connection ended
@@ -342,15 +342,15 @@ main() {
         # If the NAS just woke up
         if [ $awake -eq "0" ]; then
             awake="1"
-             ts_wakeup=`$BIN_DATE +%s`           
+             ts_wakeup=`$BIN_DATE +%s`
             ts_last_online_device=`$BIN_DATE +%s`
 
             log_info "$ACPI_STATE_LOGFILE" "S0"
             log_info "$LOGFILE" "NAS just woke up (S0). Preventing sleep during the next $I_DELAY_PREVENT_SLEEP_AFTER_WAKE s"
 
-            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then    
+            if [ $I_MAIL_ACPI_CHANGE -eq "1" ]; then
                 get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "NAS just woke up (S0)"
-            fi    
+            fi
         fi
 
         # Check if in always_on timeslot
@@ -368,7 +368,7 @@ main() {
             # Check if an ingoing ssh connection exist
             if $BIN_SOCKSTAT -c | grep "sshd" > /dev/null ; then
                 ts_last_ssh=`$BIN_DATE +%s`
-                ssh_sleep_prevent="1"                
+                ssh_sleep_prevent="1"
                 [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Incoming SSH connection detected"
             else
                 delta_t=$((`$BIN_DATE +%s`-$ts_last_ssh))
@@ -378,7 +378,7 @@ main() {
                 fi
             fi
         fi
-        
+
         # Check if curfew is reached
         curfew_sleep_request="0"
         if [ $I_CHECK_CURFEW_ACTIVE -eq "1" ]; then
@@ -389,10 +389,10 @@ main() {
         fi
 
         # Check if no other devices are online for a certain duration
-        noonline_sleep_request="0"    
+        noonline_sleep_request="0"
         if [ $I_CHECK_NOONLINE_ACTIVE -eq "1" ]; then
             any_device_online="0"
-            for ip_addr in $I_IP_ADDRS; do     
+            for ip_addr in $I_IP_ADDRS; do
                 if $BIN_PING -c 1 -t 1 $ip_addr > /dev/null ; then
                     any_device_online="1"
                     [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "Online device detected: $ip_addr (skipping any other device)"
@@ -400,13 +400,13 @@ main() {
                 fi
             done
 
-            if [ "$any_device_online" -eq "1" ]; then    
+            if [ "$any_device_online" -eq "1" ]; then
                 ts_last_online_device=`$BIN_DATE +%s`
             else
                 delta_t=$((`$BIN_DATE +%s`-$ts_last_online_device))
                 [ $I_VERBOSE -eq "1" ] && log_info "$LOGFILE" "No devices online for $delta_t s"
                 if [ "$delta_t" -gt "$I_DELAY_NOONLINE" ]; then
-                    noonline_sleep_request="1"    
+                    noonline_sleep_request="1"
                 fi
             fi
         fi
@@ -432,7 +432,7 @@ main() {
             allow_acquire_locks
         fi
 
-        # wait until next poll    
+        # wait until next poll
         sleep $I_POLL_INTERVAL
     done
 }
@@ -448,7 +448,7 @@ if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
 else
     $BIN_RM "$TMPFILE_ARGS"
     log_info "$LOGFILE" "-------------------------------------"
-    
+
         # Return the log entries that have been logged during the current
         # execution of the script
     ! main && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "Sleep management issue"

--- a/manageAcpi.sh
+++ b/manageAcpi.sh
@@ -120,14 +120,14 @@ parseInputParams() {
     while getopts ":p:w:a:s:c:n:vm" opt; do
         
         case $opt in
-            p)    echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
+            p) echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_POLL_INTERVAL="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -p. Should be a positive integer"
                     return 1
                 fi ;;
-            w)    echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
+            w) echo "$OPTARG" | grep -E "^$regex_dur$" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_DELAY_PREVENT_SLEEP_AFTER_WAKE="$OPTARG"
 
@@ -142,7 +142,7 @@ parseInputParams() {
                     echo "Invalid parameter \"$OPTARG\" for option: -w. Should be a positive integer"
                     return 1
                 fi ;;
-            a)    echo "$OPTARG" | grep -E "$regex_a" >/dev/null
+            a) echo "$OPTARG" | grep -E "$regex_a" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_CHECK_ALWAYS_ON="1"    
                     I_BEG_ALWAYS_ON=`echo "$OPTARG" | cut -f1 -d,`
@@ -151,7 +151,7 @@ parseInputParams() {
                     echo "Invalid parameter \"$OPTARG\" for option: -a. Should be \"hh:mm,hh:mm\""
                     return 1
                 fi ;;
-            s)    echo "$OPTARG" | grep -E "$regex_dur" >/dev/null
+            s) echo "$OPTARG" | grep -E "$regex_dur" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_CHECK_SSH_ACTIVE="1"            
                     I_DELAY_SSH="$OPTARG"
@@ -159,7 +159,7 @@ parseInputParams() {
                     echo "$LOGFILE" "Invalid parameter \"$OPTARG\" for option: -s. Should be a positive integer"
                     return 1
                 fi ;;
-            c)    echo "$OPTARG" | grep -E "$regex_c" >/dev/null
+            c) echo "$OPTARG" | grep -E "$regex_c" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_CHECK_CURFEW_ACTIVE="1"    
                     I_BEG_POLL_CURFEW=`echo "$OPTARG" | cut -f1 -d,`            
@@ -169,7 +169,7 @@ parseInputParams() {
                     echo "Invalid parameter \"$OPTARG\" for option: -c. Should be \"hh:mm,hh:mm,acpi_state\""
                     return 1
                 fi ;;
-            n)    echo "$OPTARG" | grep -E "$regex_n" >/dev/null
+            n) echo "$OPTARG" | grep -E "$regex_n" >/dev/null
                 if [ "$?" -eq "0" ] ; then
                     I_CHECK_NOONLINE_ACTIVE="1"
                     I_IP_ADDRS=`echo "$OPTARG" | cut -f1 -d, | sed 's/+/ /g'`
@@ -179,8 +179,8 @@ parseInputParams() {
                     echo "Invalid parameter \"$OPTARG\" for option: -n. Should be \"ips,delay,acpi_state\""
                     return 1
                 fi ;;
-            v)    I_VERBOSE=1 ;;
-            m)    I_MAIL_ACPI_CHANGE=1 ;;
+            v) I_VERBOSE=1 ;;
+            m) I_MAIL_ACPI_CHANGE=1 ;;
             \?)
                 echo "Invalid option: -$OPTARG"
                 return 1 ;;

--- a/manageSnapshots.sh
+++ b/manageSnapshots.sh
@@ -12,21 +12,21 @@
 #
 # Usage: manageSnapshots.sh [-r depth] [-n] [-h num] [-d num] [-w num] [-m num] [-k] filesystem
 #
-#	-r depth : recursion depth. Recursively process any children of the filesystem,
-#		limiting the recursion to depth.
-#		 A depth of 1 will process only the fs and its direct children.
-#		 A negative depth will process the fs and all its children recursively
-# 	-n : Do not create a new snapshot of the file system
-#	-h num : Keep 'num' hourly snapshots (by default: 24) (<0 for all)
-#	-d num : Keep 'num' daily snapshots (by default: 15) (<0 for all)
-#	-w num : Keep 'num' weekly snapshots (by default: 8) (<0 for all)
-#	-m num : Keep 'num' monthly snapshots (by default: 12) (<0 for all)
-#	-k : Keep all snapshots (This option superseeds -h, -d, -w, -m)
-#	filesystem : zfs filesystem for which a snapshot shall be created
+#    -r depth : recursion depth. Recursively process any children of the filesystem,
+#        limiting the recursion to depth.
+#         A depth of 1 will process only the fs and its direct children.
+#         A negative depth will process the fs and all its children recursively
+#     -n : Do not create a new snapshot of the file system
+#    -h num : Keep 'num' hourly snapshots (by default: 24) (<0 for all)
+#    -d num : Keep 'num' daily snapshots (by default: 15) (<0 for all)
+#    -w num : Keep 'num' weekly snapshots (by default: 8) (<0 for all)
+#    -m num : Keep 'num' monthly snapshots (by default: 12) (<0 for all)
+#    -k : Keep all snapshots (This option superseeds -h, -d, -w, -m)
+#    filesystem : zfs filesystem for which a snapshot shall be created
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -46,24 +46,24 @@ readonly TMPFILE_ARGS="$CFG_TMP_FOLDER/$SCRIPT_NAME.$$.args.tmp"
 ARGUMENTS="$@"
 
 # Initialization of the constants
-I_GENERATE_SNAPSHOT=1	# By default, the script shall generate snapshots (1=true)
+I_GENERATE_SNAPSHOT=1    # By default, the script shall generate snapshots (1=true)
 
-I_MAX_NB_HOURLY=24	# Default number of hourly snapshots to be kept
-I_MAX_NB_DAILY=15	# Default number of daily snapshots to be kept
-I_MAX_NB_WEEKLY=8	# Default number of weekly snapshots to be kept
-I_MAX_NB_MONTHLY=12	# Default number of monthly snapshots to be kept
+I_MAX_NB_HOURLY=24    # Default number of hourly snapshots to be kept
+I_MAX_NB_DAILY=15    # Default number of daily snapshots to be kept
+I_MAX_NB_WEEKLY=8    # Default number of weekly snapshots to be kept
+I_MAX_NB_MONTHLY=12    # Default number of monthly snapshots to be kept
 
-I_DEPTH="-1"		# Default recursion depth
+I_DEPTH="-1"        # Default recursion depth
 
-readonly S_IN_HOUR=36000	# Number of seconds in an hour
-readonly S_IN_DAY=86400		# Number of seconds in a day
-readonly S_IN_WEEK=604800	# Number of seconds in a week
-readonly S_IN_MONTH=2629744	# Number of seconds in a month
+readonly S_IN_HOUR=36000    # Number of seconds in an hour
+readonly S_IN_DAY=86400        # Number of seconds in a day
+readonly S_IN_WEEK=604800    # Number of seconds in a week
+readonly S_IN_MONTH=2629744    # Number of seconds in a month
 
-readonly HOURLY_TAG="type01"	# It is important that the changing part of the tag are exactly 2 digits	
-readonly DAILY_TAG="type02"	# in order to be able to show all tags in the windows shadow copy client
-readonly WEEKLY_TAG="type03"	# Shadow copy should be enable in the NAS4Free GUI under
-readonly MONTHLY_TAG="type04"	# Services|CIFS/SMB|Shares
+readonly HOURLY_TAG="type01"    # It is important that the changing part of the tag are exactly 2 digits    
+readonly DAILY_TAG="type02"    # in order to be able to show all tags in the windows shadow copy client
+readonly WEEKLY_TAG="type03"    # Shadow copy should be enable in the NAS4Free GUI under
+readonly MONTHLY_TAG="type04"    # Services|CIFS/SMB|Shares
 
 
 
@@ -74,99 +74,99 @@ readonly MONTHLY_TAG="type04"	# Services|CIFS/SMB|Shares
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local regex_int keep_all_snap opt fs_without_slash
-	
-	regex_int='^[+-]{0,1}[0-9]+$'	# regex for integer (positive or negative)
-	
-	keep_all_snap="0"
+    local regex_int keep_all_snap opt fs_without_slash
+    
+    regex_int='^[+-]{0,1}[0-9]+$'    # regex for integer (positive or negative)
+    
+    keep_all_snap="0"
 
-	# get the mandatory script parameter (Filesystem for which a snapshot shall be created)
-	# this argument is parsed at first because it is required to compute the log file name
-	if [ $# -gt 0 ]; then
-		eval I_FILESYSTEM=\${$#}			# Filesystem to snapshot
-	else
-		echo "Name of the filesystem to snapshot not provided when calling \"$SCRIPT_NAME\"" | sendMail "Snapshot management issue"
-		exit 1
-	fi
+    # get the mandatory script parameter (Filesystem for which a snapshot shall be created)
+    # this argument is parsed at first because it is required to compute the log file name
+    if [ $# -gt 0 ]; then
+        eval I_FILESYSTEM=\${$#}            # Filesystem to snapshot
+    else
+        echo "Name of the filesystem to snapshot not provided when calling \"$SCRIPT_NAME\"" | sendMail "Snapshot management issue"
+        exit 1
+    fi
 
-	# Initialization of the log file path
-	fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`	# The fs without '/' that is not allowed in a file name
-	LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"
-	
-	# Check if the filesystem for which the snapshots shall be managed is available
-	if ! $BIN_ZFS list "$I_FILESYSTEM" 1>/dev/null 2>/dev/null; then
-		echo "Unknown file system: \"$I_FILESYSTEM\""
-		return 1
-	fi	
-	
-	# parse the optional parameters
-	while getopts ":r:nh:d:w:m:k" opt; do
-		case $opt in
-			n) 	I_GENERATE_SNAPSHOT=0 ;;
-			r) 	echo "$OPTARG" | grep -E "$regex_int" >/dev/null	# Check if positive or negative integer
-				if [ "$?" -eq "0" ] ; then
-					I_DEPTH="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -r. Should be an integer."
-					return 1
-				fi ;;
-			h) 	echo "$OPTARG" | grep -E "$regex_int" >/dev/null	# Check if positive or negative integer
-				if [ "$?" -eq "0" ] ; then
-					I_MAX_NB_HOURLY="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
-					return 1
-				fi ;;
-			d) 	echo "$OPTARG" | grep -E "$regex_int" >/dev/null	# Check if positive or negative integer
-				if [ "$?" -eq "0" ] ; then
-					I_MAX_NB_DAILY="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
-					return 1
-				fi ;;
-			w) 	echo "$OPTARG" | grep -E "$regex_int" >/dev/null	# Check if positive or negative integer
-				if [ "$?" -eq "0" ] ; then
-					I_MAX_NB_WEEKLY="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
-					return 1
-				fi ;;
-			m) 	echo "$OPTARG" | grep -E "$regex_int" >/dev/null	# Check if positive or negative integer
-				if [ "$?" -eq "0" ] ; then
-					I_MAX_NB_MONTHLY="$OPTARG"
-				else
-					echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
-					return 1
-				fi ;;
-			k) 	keep_all_snap="1" ;;
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-			:)
-				echo "Option -$OPTARG requires an argument"
-				return 1 ;;
-		esac
-	done
+    # Initialization of the log file path
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    # The fs without '/' that is not allowed in a file name
+    LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"
+    
+    # Check if the filesystem for which the snapshots shall be managed is available
+    if ! $BIN_ZFS list "$I_FILESYSTEM" 1>/dev/null 2>/dev/null; then
+        echo "Unknown file system: \"$I_FILESYSTEM\""
+        return 1
+    fi    
+    
+    # parse the optional parameters
+    while getopts ":r:nh:d:w:m:k" opt; do
+        case $opt in
+            n)     I_GENERATE_SNAPSHOT=0 ;;
+            r)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+                if [ "$?" -eq "0" ] ; then
+                    I_DEPTH="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -r. Should be an integer."
+                    return 1
+                fi ;;
+            h)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+                if [ "$?" -eq "0" ] ; then
+                    I_MAX_NB_HOURLY="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
+                    return 1
+                fi ;;
+            d)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+                if [ "$?" -eq "0" ] ; then
+                    I_MAX_NB_DAILY="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
+                    return 1
+                fi ;;
+            w)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+                if [ "$?" -eq "0" ] ; then
+                    I_MAX_NB_WEEKLY="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
+                    return 1
+                fi ;;
+            m)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+                if [ "$?" -eq "0" ] ; then
+                    I_MAX_NB_MONTHLY="$OPTARG"
+                else
+                    echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
+                    return 1
+                fi ;;
+            k)     keep_all_snap="1" ;;
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            :)
+                echo "Option -$OPTARG requires an argument"
+                return 1 ;;
+        esac
+    done
 
-	# If "keep all snapshots" was selected
-	if [ $keep_all_snap -eq "1" ]; then
-		I_MAX_NB_HOURLY="-1"
-		I_MAX_NB_DAILY="-1"
-		I_MAX_NB_WEEKLY="-1"
-		I_MAX_NB_MONTHLY="-1"
-	fi
+    # If "keep all snapshots" was selected
+    if [ $keep_all_snap -eq "1" ]; then
+        I_MAX_NB_HOURLY="-1"
+        I_MAX_NB_DAILY="-1"
+        I_MAX_NB_WEEKLY="-1"
+        I_MAX_NB_MONTHLY="-1"
+    fi
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "1" ]; then
-		echo "Exactly one mandatory argument shall be provided"
-		return 1
-	fi	
-	
-	return 0
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "1" ]; then
+        echo "Exactly one mandatory argument shall be provided"
+        return 1
+    fi    
+    
+    return 0
 }
 
 ##################################
@@ -179,20 +179,20 @@ parseInputParams() {
 # Return : age in s
 ##################################
 newestSnapshotAge() {
-	local newestSnap snapCreationDate ageSnap
+    local newestSnap snapCreationDate ageSnap
 
-	filesystem="$1"
-	tag="$2"
-	newestSnap=`sortSnapshots "$filesystem" "$tag" | head -n 1`
+    filesystem="$1"
+    tag="$2"
+    newestSnap=`sortSnapshots "$filesystem" "$tag" | head -n 1`
 
-	if [ -z "$newestSnap" ]; then
-		snapCreationDate="0"
-	else
-		snapCreationDate=`getSnapTimestamp1970 $newestSnap`
-	fi
-	
-	ageSnap=$((`$BIN_DATE +%s`-$snapCreationDate))
-	echo $ageSnap
+    if [ -z "$newestSnap" ]; then
+        snapCreationDate="0"
+    else
+        snapCreationDate=`getSnapTimestamp1970 $newestSnap`
+    fi
+    
+    ageSnap=$((`$BIN_DATE +%s`-$snapCreationDate))
+    echo $ageSnap
 }
 
 ##################################
@@ -203,41 +203,41 @@ newestSnapshotAge() {
 # Param 1: filesystem
 ##################################
 createSnapshot() {
-	local filesystem ageMonthlySnap ageWeeklySnap ageDailySnap \
-		now newSnapshotName fullNewSnapshotname
-	
-	filesystem="$1"
+    local filesystem ageMonthlySnap ageWeeklySnap ageDailySnap \
+        now newSnapshotName fullNewSnapshotname
+    
+    filesystem="$1"
 
-	ageMonthlySnap=`newestSnapshotAge "$filesystem" "$MONTHLY_TAG"`
-	ageWeeklySnap=`newestSnapshotAge "$filesystem" "$WEEKLY_TAG"`
-	ageDailySnap=`newestSnapshotAge "$filesystem" "$DAILY_TAG"`
+    ageMonthlySnap=`newestSnapshotAge "$filesystem" "$MONTHLY_TAG"`
+    ageWeeklySnap=`newestSnapshotAge "$filesystem" "$WEEKLY_TAG"`
+    ageDailySnap=`newestSnapshotAge "$filesystem" "$DAILY_TAG"`
 
-	# Find out which snapshot tag shall be used
-	if [ $I_MAX_NB_MONTHLY -ne 0 -a $ageMonthlySnap -ge $S_IN_MONTH ]; then
-		tag="$MONTHLY_TAG"
-	elif [ $I_MAX_NB_WEEKLY -ne 0 -a $ageWeeklySnap -ge $S_IN_WEEK ]; then
-		tag="$WEEKLY_TAG"
-	elif [ $I_MAX_NB_DAILY -ne 0 -a $ageDailySnap -ge $S_IN_DAY ]; then
-		tag="$DAILY_TAG"
-	elif [ $I_MAX_NB_HOURLY -ne 0 ]; then
-		tag="$HOURLY_TAG"
-	else
-		log_info "$LOGFILE" "$filesystem: Currently, no need to create any snapshot"
-		return 0
-	fi
+    # Find out which snapshot tag shall be used
+    if [ $I_MAX_NB_MONTHLY -ne 0 -a $ageMonthlySnap -ge $S_IN_MONTH ]; then
+        tag="$MONTHLY_TAG"
+    elif [ $I_MAX_NB_WEEKLY -ne 0 -a $ageWeeklySnap -ge $S_IN_WEEK ]; then
+        tag="$WEEKLY_TAG"
+    elif [ $I_MAX_NB_DAILY -ne 0 -a $ageDailySnap -ge $S_IN_DAY ]; then
+        tag="$DAILY_TAG"
+    elif [ $I_MAX_NB_HOURLY -ne 0 ]; then
+        tag="$HOURLY_TAG"
+    else
+        log_info "$LOGFILE" "$filesystem: Currently, no need to create any snapshot"
+        return 0
+    fi
 
-	# Create the snapshot
-	now=`$BIN_DATE +%s`
-	newSnapshotName=`generateSnapshotName "$tag" "$now"`
+    # Create the snapshot
+    now=`$BIN_DATE +%s`
+    newSnapshotName=`generateSnapshotName "$tag" "$now"`
 
-	fullNewSnapshotname="$filesystem@$newSnapshotName"
-	log_info "$LOGFILE" "$filesystem: Creating new snapshot \"$fullNewSnapshotname\""
-	if `$BIN_ZFS snapshot $fullNewSnapshotname>/dev/null`; then
-		return 0
-	else
-		log_error "$LOGFILE" "$filesystem: Problem while creating snapshot $fullNewSnapshotname (A snapshot having the same name may already exist)"
-		return 1
-	fi
+    fullNewSnapshotname="$filesystem@$newSnapshotName"
+    log_info "$LOGFILE" "$filesystem: Creating new snapshot \"$fullNewSnapshotname\""
+    if `$BIN_ZFS snapshot $fullNewSnapshotname>/dev/null`; then
+        return 0
+    else
+        log_error "$LOGFILE" "$filesystem: Problem while creating snapshot $fullNewSnapshotname (A snapshot having the same name may already exist)"
+        return 1
+    fi
 }
 
 
@@ -250,97 +250,97 @@ createSnapshot() {
 # Param 3: max number of snapshots to be kept (all are kept if value is negative)
 ##################################
 deleteOldSnapshots() {
-	local filesystem tag maxNb returnCode
+    local filesystem tag maxNb returnCode
 
-	filesystem="$1"
-	tag="$2"
-	maxNb="$3"
+    filesystem="$1"
+    tag="$2"
+    maxNb="$3"
 
-	returnCode=0
+    returnCode=0
 
-	# Check if all snapshots are required to be kept
-	if [ "$maxNb" -lt "0" ]; then
-		log_info "$LOGFILE" "$filesystem: All snapshots with tag \"$tag\" kept"
-		return 0
-	fi
-	
-	# Delete the snapshots that are too old in the current sub filesystem
-	for snapshot in `sortSnapshots $filesystem $tag | tail -n +$((maxNb+1))`; do
+    # Check if all snapshots are required to be kept
+    if [ "$maxNb" -lt "0" ]; then
+        log_info "$LOGFILE" "$filesystem: All snapshots with tag \"$tag\" kept"
+        return 0
+    fi
+    
+    # Delete the snapshots that are too old in the current sub filesystem
+    for snapshot in `sortSnapshots $filesystem $tag | tail -n +$((maxNb+1))`; do
 
-		# Destroy the snapshots that are too old
-		if ! $BIN_ZFS destroy $snapshot; then
-		        log_error "$LOGFILE" "$filesystem: Problem while trying to delete snapshot \"$snapshot\""
-		        returnCode=1
-		else
-			log_info "$LOGFILE" "$filesystem: Snapshot \"$snapshot\" DELETED"
-		fi
-	done
+        # Destroy the snapshots that are too old
+        if ! $BIN_ZFS destroy $snapshot; then
+                log_error "$LOGFILE" "$filesystem: Problem while trying to delete snapshot \"$snapshot\""
+                returnCode=1
+        else
+            log_info "$LOGFILE" "$filesystem: Snapshot \"$snapshot\" DELETED"
+        fi
+    done
 
-	return $returnCode
+    return $returnCode
 }
 
 ##################################
 # Main
 ##################################
 main() {
-	local returnCode depth_flag
-	returnCode=0
+    local returnCode depth_flag
+    returnCode=0
 
-	log_info "$LOGFILE" "Starting snapshot script for dataset \"$I_FILESYSTEM\" (depth: $I_DEPTH)"
-	log_info "$LOGFILE" "Keeping up to $I_MAX_NB_HOURLY hourly / $I_MAX_NB_DAILY daily / $I_MAX_NB_WEEKLY weekly / $I_MAX_NB_MONTHLY monthly snapshots (<0 = all)"
+    log_info "$LOGFILE" "Starting snapshot script for dataset \"$I_FILESYSTEM\" (depth: $I_DEPTH)"
+    log_info "$LOGFILE" "Keeping up to $I_MAX_NB_HOURLY hourly / $I_MAX_NB_DAILY daily / $I_MAX_NB_WEEKLY weekly / $I_MAX_NB_MONTHLY monthly snapshots (<0 = all)"
 
-	# Compute the arguments required to process the fs ar the requested depth
-	if [ "$I_DEPTH" -lt "0" ]; then
-		depth_flag="-r"
-	else
-		depth_flag="-d $I_DEPTH"	
-	fi
+    # Compute the arguments required to process the fs ar the requested depth
+    if [ "$I_DEPTH" -lt "0" ]; then
+        depth_flag="-r"
+    else
+        depth_flag="-d $I_DEPTH"    
+    fi
 
-	# Itterate the filesystems	
-	for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H $depth_flag -o name $I_FILESYSTEM`; do
-		# If requested make a snapshot of all file systems within the filesystem $I_FILESYSTEM
-		if [ "$I_GENERATE_SNAPSHOT" -eq "1" ]; then	
-			if ! createSnapshot $subfilesystem; then
-				returnCode=1	
-			fi
-		else
-			log_info "$LOGFILE" "$subfilesystem: Snapshot creation deactivated (no snapshot created)"
-		fi
+    # Itterate the filesystems    
+    for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H $depth_flag -o name $I_FILESYSTEM`; do
+        # If requested make a snapshot of all file systems within the filesystem $I_FILESYSTEM
+        if [ "$I_GENERATE_SNAPSHOT" -eq "1" ]; then    
+            if ! createSnapshot $subfilesystem; then
+                returnCode=1    
+            fi
+        else
+            log_info "$LOGFILE" "$subfilesystem: Snapshot creation deactivated (no snapshot created)"
+        fi
 
-		# Delete the superfluous snapshots for the filesystem
-		if ! deleteOldSnapshots "$subfilesystem" "$HOURLY_TAG" "$I_MAX_NB_HOURLY"; then
-			returnCode=1	
-		fi
-		if ! deleteOldSnapshots "$subfilesystem" "$DAILY_TAG" "$I_MAX_NB_DAILY"; then
-			returnCode=1	
-		fi
-		if ! deleteOldSnapshots "$subfilesystem" "$WEEKLY_TAG" "$I_MAX_NB_WEEKLY"; then
-			returnCode=1	
-		fi
-		if ! deleteOldSnapshots "$subfilesystem" "$MONTHLY_TAG" "$I_MAX_NB_MONTHLY"; then
-			returnCode=1	
-		fi 		
-	done
+        # Delete the superfluous snapshots for the filesystem
+        if ! deleteOldSnapshots "$subfilesystem" "$HOURLY_TAG" "$I_MAX_NB_HOURLY"; then
+            returnCode=1    
+        fi
+        if ! deleteOldSnapshots "$subfilesystem" "$DAILY_TAG" "$I_MAX_NB_DAILY"; then
+            returnCode=1    
+        fi
+        if ! deleteOldSnapshots "$subfilesystem" "$WEEKLY_TAG" "$I_MAX_NB_WEEKLY"; then
+            returnCode=1    
+        fi
+        if ! deleteOldSnapshots "$subfilesystem" "$MONTHLY_TAG" "$I_MAX_NB_MONTHLY"; then
+            returnCode=1    
+        fi         
+    done
 
-	return $returnCode
+    return $returnCode
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`	# The fs without '/' that is not allowed in a file name
-	run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    # The fs without '/' that is not allowed in a file name
+    run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"

--- a/manageSnapshots.sh
+++ b/manageSnapshots.sh
@@ -26,7 +26,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -46,24 +46,24 @@ readonly TMPFILE_ARGS="$CFG_TMP_FOLDER/$SCRIPT_NAME.$$.args.tmp"
 ARGUMENTS="$@"
 
 # Initialization of the constants
-I_GENERATE_SNAPSHOT=1    # By default, the script shall generate snapshots (1=true)
+I_GENERATE_SNAPSHOT=1  # By default, the script shall generate snapshots (1=true)
 
-I_MAX_NB_HOURLY=24    # Default number of hourly snapshots to be kept
-I_MAX_NB_DAILY=15    # Default number of daily snapshots to be kept
-I_MAX_NB_WEEKLY=8    # Default number of weekly snapshots to be kept
-I_MAX_NB_MONTHLY=12    # Default number of monthly snapshots to be kept
+I_MAX_NB_HOURLY=24  # Default number of hourly snapshots to be kept
+I_MAX_NB_DAILY=15  # Default number of daily snapshots to be kept
+I_MAX_NB_WEEKLY=8  # Default number of weekly snapshots to be kept
+I_MAX_NB_MONTHLY=12  # Default number of monthly snapshots to be kept
 
-I_DEPTH="-1"        # Default recursion depth
+I_DEPTH="-1"  # Default recursion depth
 
-readonly S_IN_HOUR=36000    # Number of seconds in an hour
-readonly S_IN_DAY=86400        # Number of seconds in a day
-readonly S_IN_WEEK=604800    # Number of seconds in a week
-readonly S_IN_MONTH=2629744    # Number of seconds in a month
+readonly S_IN_HOUR=36000  # Number of seconds in an hour
+readonly S_IN_DAY=86400  # Number of seconds in a day
+readonly S_IN_WEEK=604800  # Number of seconds in a week
+readonly S_IN_MONTH=2629744  # Number of seconds in a month
 
-readonly HOURLY_TAG="type01"    # It is important that the changing part of the tag are exactly 2 digits
-readonly DAILY_TAG="type02"    # in order to be able to show all tags in the windows shadow copy client
-readonly WEEKLY_TAG="type03"    # Shadow copy should be enable in the NAS4Free GUI under
-readonly MONTHLY_TAG="type04"    # Services|CIFS/SMB|Shares
+readonly HOURLY_TAG="type01"  # It is important that the changing part of the tag are exactly 2 digits
+readonly DAILY_TAG="type02"  # in order to be able to show all tags in the windows shadow copy client
+readonly WEEKLY_TAG="type03"  # Shadow copy should be enable in the NAS4Free GUI under
+readonly MONTHLY_TAG="type04"  # Services|CIFS/SMB|Shares
 
 
 
@@ -76,21 +76,21 @@ readonly MONTHLY_TAG="type04"    # Services|CIFS/SMB|Shares
 parseInputParams() {
     local regex_int keep_all_snap opt fs_without_slash
 
-    regex_int='^[+-]{0,1}[0-9]+$'    # regex for integer (positive or negative)
+    regex_int='^[+-]{0,1}[0-9]+$'  # regex for integer (positive or negative)
 
     keep_all_snap="0"
 
     # get the mandatory script parameter (Filesystem for which a snapshot shall be created)
     # this argument is parsed at first because it is required to compute the log file name
     if [ $# -gt 0 ]; then
-        eval I_FILESYSTEM=\${$#}            # Filesystem to snapshot
+        eval I_FILESYSTEM=\${$#}  # Filesystem to snapshot
     else
         echo "Name of the filesystem to snapshot not provided when calling \"$SCRIPT_NAME\"" | sendMail "Snapshot management issue"
         exit 1
     fi
 
     # Initialization of the log file path
-    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    # The fs without '/' that is not allowed in a file name
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`  # The fs without '/' that is not allowed in a file name
     LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"
 
     # Check if the filesystem for which the snapshots shall be managed is available
@@ -103,35 +103,35 @@ parseInputParams() {
     while getopts ":r:nh:d:w:m:k" opt; do
         case $opt in
             n) I_GENERATE_SNAPSHOT=0 ;;
-            r) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            r) echo "$OPTARG" | grep -E "$regex_int" >/dev/null  # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_DEPTH="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -r. Should be an integer."
                     return 1
                 fi ;;
-            h) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            h) echo "$OPTARG" | grep -E "$regex_int" >/dev/null  # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_HOURLY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            d) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            d) echo "$OPTARG" | grep -E "$regex_int" >/dev/null  # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_DAILY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            w) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            w) echo "$OPTARG" | grep -E "$regex_int" >/dev/null  # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_WEEKLY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            m) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            m) echo "$OPTARG" | grep -E "$regex_int" >/dev/null  # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_MONTHLY="$OPTARG"
                 else
@@ -337,7 +337,7 @@ else
     cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
     # run script if possible (lock not existing)
-    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    # The fs without '/' that is not allowed in a file name
+    fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`  # The fs without '/' that is not allowed in a file name
     run_main "$LOGFILE" "$SCRIPT_NAME.$fs_without_slash"
     # in case of error, send mail with extract of log file
     [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"

--- a/manageSnapshots.sh
+++ b/manageSnapshots.sh
@@ -60,7 +60,7 @@ readonly S_IN_DAY=86400        # Number of seconds in a day
 readonly S_IN_WEEK=604800    # Number of seconds in a week
 readonly S_IN_MONTH=2629744    # Number of seconds in a month
 
-readonly HOURLY_TAG="type01"    # It is important that the changing part of the tag are exactly 2 digits    
+readonly HOURLY_TAG="type01"    # It is important that the changing part of the tag are exactly 2 digits
 readonly DAILY_TAG="type02"    # in order to be able to show all tags in the windows shadow copy client
 readonly WEEKLY_TAG="type03"    # Shadow copy should be enable in the NAS4Free GUI under
 readonly MONTHLY_TAG="type04"    # Services|CIFS/SMB|Shares
@@ -75,9 +75,9 @@ readonly MONTHLY_TAG="type04"    # Services|CIFS/SMB|Shares
 ##################################
 parseInputParams() {
     local regex_int keep_all_snap opt fs_without_slash
-    
+
     regex_int='^[+-]{0,1}[0-9]+$'    # regex for integer (positive or negative)
-    
+
     keep_all_snap="0"
 
     # get the mandatory script parameter (Filesystem for which a snapshot shall be created)
@@ -92,13 +92,13 @@ parseInputParams() {
     # Initialization of the log file path
     fs_without_slash=`echo "$I_FILESYSTEM" | sed 's!/!_!g'`    # The fs without '/' that is not allowed in a file name
     LOGFILE="$CFG_LOG_FOLDER/$SCRIPT_NAME.$fs_without_slash.log"
-    
+
     # Check if the filesystem for which the snapshots shall be managed is available
     if ! $BIN_ZFS list "$I_FILESYSTEM" 1>/dev/null 2>/dev/null; then
         echo "Unknown file system: \"$I_FILESYSTEM\""
         return 1
-    fi    
-    
+    fi
+
     # parse the optional parameters
     while getopts ":r:nh:d:w:m:k" opt; do
         case $opt in
@@ -158,14 +158,14 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "1" ]; then
         echo "Exactly one mandatory argument shall be provided"
         return 1
-    fi    
-    
+    fi
+
     return 0
 }
 
@@ -190,7 +190,7 @@ newestSnapshotAge() {
     else
         snapCreationDate=`getSnapTimestamp1970 $newestSnap`
     fi
-    
+
     ageSnap=$((`$BIN_DATE +%s`-$snapCreationDate))
     echo $ageSnap
 }
@@ -205,7 +205,7 @@ newestSnapshotAge() {
 createSnapshot() {
     local filesystem ageMonthlySnap ageWeeklySnap ageDailySnap \
         now newSnapshotName fullNewSnapshotname
-    
+
     filesystem="$1"
 
     ageMonthlySnap=`newestSnapshotAge "$filesystem" "$MONTHLY_TAG"`
@@ -263,7 +263,7 @@ deleteOldSnapshots() {
         log_info "$LOGFILE" "$filesystem: All snapshots with tag \"$tag\" kept"
         return 0
     fi
-    
+
     # Delete the snapshots that are too old in the current sub filesystem
     for snapshot in `sortSnapshots $filesystem $tag | tail -n +$((maxNb+1))`; do
 
@@ -293,15 +293,15 @@ main() {
     if [ "$I_DEPTH" -lt "0" ]; then
         depth_flag="-r"
     else
-        depth_flag="-d $I_DEPTH"    
+        depth_flag="-d $I_DEPTH"
     fi
 
-    # Itterate the filesystems    
+    # Itterate the filesystems
     for subfilesystem in `$BIN_ZFS list -t filesystem,volume -H $depth_flag -o name $I_FILESYSTEM`; do
         # If requested make a snapshot of all file systems within the filesystem $I_FILESYSTEM
-        if [ "$I_GENERATE_SNAPSHOT" -eq "1" ]; then    
+        if [ "$I_GENERATE_SNAPSHOT" -eq "1" ]; then
             if ! createSnapshot $subfilesystem; then
-                returnCode=1    
+                returnCode=1
             fi
         else
             log_info "$LOGFILE" "$subfilesystem: Snapshot creation deactivated (no snapshot created)"
@@ -309,17 +309,17 @@ main() {
 
         # Delete the superfluous snapshots for the filesystem
         if ! deleteOldSnapshots "$subfilesystem" "$HOURLY_TAG" "$I_MAX_NB_HOURLY"; then
-            returnCode=1    
+            returnCode=1
         fi
         if ! deleteOldSnapshots "$subfilesystem" "$DAILY_TAG" "$I_MAX_NB_DAILY"; then
-            returnCode=1    
+            returnCode=1
         fi
         if ! deleteOldSnapshots "$subfilesystem" "$WEEKLY_TAG" "$I_MAX_NB_WEEKLY"; then
-            returnCode=1    
+            returnCode=1
         fi
         if ! deleteOldSnapshots "$subfilesystem" "$MONTHLY_TAG" "$I_MAX_NB_MONTHLY"; then
-            returnCode=1    
-        fi         
+            returnCode=1
+        fi
     done
 
     return $returnCode

--- a/manageSnapshots.sh
+++ b/manageSnapshots.sh
@@ -102,43 +102,43 @@ parseInputParams() {
     # parse the optional parameters
     while getopts ":r:nh:d:w:m:k" opt; do
         case $opt in
-            n)     I_GENERATE_SNAPSHOT=0 ;;
-            r)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            n) I_GENERATE_SNAPSHOT=0 ;;
+            r) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_DEPTH="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -r. Should be an integer."
                     return 1
                 fi ;;
-            h)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            h) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_HOURLY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            d)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            d) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_DAILY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            w)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            w) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_WEEKLY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            m)     echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
+            m) echo "$OPTARG" | grep -E "$regex_int" >/dev/null    # Check if positive or negative integer
                 if [ "$?" -eq "0" ] ; then
                     I_MAX_NB_MONTHLY="$OPTARG"
                 else
                     echo "Invalid parameter \"$OPTARG\" for option: -h. Should be an integer."
                     return 1
                 fi ;;
-            k)     keep_all_snap="1" ;;
+            k) keep_all_snap="1" ;;
             \?)
                 echo "Invalid option: -$OPTARG"
                 return 1 ;;

--- a/reportFromLogs.sh
+++ b/reportFromLogs.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -17,8 +17,8 @@ cd "`dirname $0`"
 . "common/commonLogFcts.sh"
 
 # Initialization of the constants
-readonly DURATION=604800			# The entries from the last week (duration in sec)
-readonly LOG_FILES="$CFG_LOG_FOLDER/*.log"	# The log files to be considered
+readonly DURATION=604800            # The entries from the last week (duration in sec)
+readonly LOG_FILES="$CFG_LOG_FOLDER/*.log"    # The log files to be considered
 
 echo "Script package version: $CFG_VERSION"
 time_limit=`$BIN_DATE -j -v-"$DURATION"S`
@@ -26,13 +26,13 @@ echo "Showing log entries appended after: $time_limit"
 
 # Appending the extract of the logs
 for f in $LOG_FILES; do
-	# Only consider files, not folders
-	if [ -f "$f" ]; then
-		echo ""
-		echo "$f"
-		echo "----------------------------"
-		get_log_entries "$f" "$DURATION"
-	fi
+    # Only consider files, not folders
+    if [ -f "$f" ]; then
+        echo ""
+        echo "$f"
+        echo "----------------------------"
+        get_log_entries "$f" "$DURATION"
+    fi
 done
 
 echo ""
@@ -43,17 +43,17 @@ echo "Summary:"
 echo "----------------------------"
 printf '%7s %7s %s\n' "WARNING" "ERROR" "log file (\"---\" means: no new log message available)"
 for f in $LOG_FILES; do
-	if [ -f "$f" ]; then
-		# check if the log does not contain any new entry
-		get_log_entries "$f" "$DURATION" >/dev/null
-		if [ $? -eq "2" ]; then
-			printf '%7s %7s %s\n' "---" "---" "$f"
-		else
-			# if the log contains any new entry
-			num_warn=`get_log_entries "$f" "$DURATION" | grep -c "$LOG_WARNING"`
-			num_err=`get_log_entries "$f" "$DURATION" | grep -c "$LOG_ERROR"`
+    if [ -f "$f" ]; then
+        # check if the log does not contain any new entry
+        get_log_entries "$f" "$DURATION" >/dev/null
+        if [ $? -eq "2" ]; then
+            printf '%7s %7s %s\n' "---" "---" "$f"
+        else
+            # if the log contains any new entry
+            num_warn=`get_log_entries "$f" "$DURATION" | grep -c "$LOG_WARNING"`
+            num_err=`get_log_entries "$f" "$DURATION" | grep -c "$LOG_ERROR"`
 
-			printf '%7d %7d %s\n' "$num_warn" "$num_err" "$f"
-		fi
-	fi
+            printf '%7d %7d %s\n' "$num_warn" "$num_err" "$f"
+        fi
+    fi
 done

--- a/reportFromLogs.sh
+++ b/reportFromLogs.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -17,8 +17,8 @@ cd "`dirname $0`"
 . "common/commonLogFcts.sh"
 
 # Initialization of the constants
-readonly DURATION=604800            # The entries from the last week (duration in sec)
-readonly LOG_FILES="$CFG_LOG_FOLDER/*.log"    # The log files to be considered
+readonly DURATION=604800  # The entries from the last week (duration in sec)
+readonly LOG_FILES="$CFG_LOG_FOLDER/*.log"  # The log files to be considered
 
 echo "Script package version: $CFG_VERSION"
 time_limit=`$BIN_DATE -j -v-"$DURATION"S`

--- a/scrubPools.sh
+++ b/scrubPools.sh
@@ -37,7 +37,7 @@ ARGUMENTS="$@"
 ##################################
 parseInputParams() {
     local opt
-    
+
     # parse the optional parameters
     # (there should be none)
     while getopts ":" opt; do
@@ -50,14 +50,14 @@ parseInputParams() {
 
     # Remove the optional arguments parsed above.
     shift $((OPTIND-1))
-    
+
     # Check if the number of mandatory parameters
     # provided is as expected
     if [ "$#" -ne "0" ]; then
         echo "No mandatory arguments should be provided"
         return 1
     fi
-    
+
     return 0
 }
 

--- a/scrubPools.sh
+++ b/scrubPools.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0`         # The name of this file
+readonly SCRIPT_NAME=`basename $0`  # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"

--- a/scrubPools.sh
+++ b/scrubPools.sh
@@ -7,7 +7,7 @@
 #############################################################################
 
 # Initialization of the script name
-readonly SCRIPT_NAME=`basename $0` 		# The name of this file
+readonly SCRIPT_NAME=`basename $0`         # The name of this file
 
 # set script path as working directory
 cd "`dirname $0`"
@@ -36,87 +36,87 @@ ARGUMENTS="$@"
 # return : 1 if an error occured, 0 otherwise
 ##################################
 parseInputParams() {
-	local opt
-	
-	# parse the optional parameters
-	# (there should be none)
-	while getopts ":" opt; do
-        	case $opt in
-			\?)
-				echo "Invalid option: -$OPTARG"
-				return 1 ;;
-        	esac
-	done
+    local opt
+    
+    # parse the optional parameters
+    # (there should be none)
+    while getopts ":" opt; do
+            case $opt in
+            \?)
+                echo "Invalid option: -$OPTARG"
+                return 1 ;;
+            esac
+    done
 
-	# Remove the optional arguments parsed above.
-	shift $((OPTIND-1))
-	
-	# Check if the number of mandatory parameters
-	# provided is as expected
-	if [ "$#" -ne "0" ]; then
-		echo "No mandatory arguments should be provided"
-		return 1
-	fi
-	
-	return 0
+    # Remove the optional arguments parsed above.
+    shift $((OPTIND-1))
+    
+    # Check if the number of mandatory parameters
+    # provided is as expected
+    if [ "$#" -ne "0" ]; then
+        echo "No mandatory arguments should be provided"
+        return 1
+    fi
+    
+    return 0
 }
 
 ##################################
 # Check if scrubing is still in progress for a given pool
 # Return : 0 if scrub is in progress,
-#	   1 otherwise
+#       1 otherwise
 ##################################
 scrubInProgress() {
-	if $BIN_ZPOOL status | grep "scrub in progress">/dev/null; then
-		return 0
-	else
-		return 1
-	fi
+    if $BIN_ZPOOL status | grep "scrub in progress">/dev/null; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 ##################################
 # Scrub all pools
 # Return : 0 no problem detected
-#	   1 problem detected
+#       1 problem detected
 ##################################
 main() {
 
-	# Starting scrubbing
-	log_info "$LOGFILE" "Starting scrubbing"
-	$BIN_ZPOOL list -H -o name | while read pool; do
-		$BIN_ZPOOL scrub $pool
-		log_info "$LOGFILE" "Starting scrubbing of pool: $pool"
-	done
+    # Starting scrubbing
+    log_info "$LOGFILE" "Starting scrubbing"
+    $BIN_ZPOOL list -H -o name | while read pool; do
+        $BIN_ZPOOL scrub $pool
+        log_info "$LOGFILE" "Starting scrubbing of pool: $pool"
+    done
 
-	# Waiting for the end of the scrubbing
-	while scrubInProgress; do sleep 10; done;
-	log_info "$LOGFILE" "Scrub finished for all pools"
+    # Waiting for the end of the scrubbing
+    while scrubInProgress; do sleep 10; done;
+    log_info "$LOGFILE" "Scrub finished for all pools"
 
-	# Check if the pools are healthy
-	if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | grep "all pools are healthy">/dev/null; then
-		ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | log_info "$LOGFILE"
-		return 0
-	else
-		$BIN_ZPOOL status -v | log_error "$LOGFILE"
-		return 1
-	fi
+    # Check if the pools are healthy
+    if ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | grep "all pools are healthy">/dev/null; then
+        ZPOOL_STATUS_NON_NATIVE_ASHIFT_IGNORE=1 $BIN_ZPOOL status -x | log_info "$LOGFILE"
+        return 0
+    else
+        $BIN_ZPOOL status -v | log_error "$LOGFILE"
+        return 1
+    fi
 }
 
 
 
 # Parse and validate the input parameters
 if ! parseInputParams $ARGUMENTS > "$TMPFILE_ARGS"; then
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
-	get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_error "$LOGFILE"
+    get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : Invalid arguments"
 else
-	log_info "$LOGFILE" "-------------------------------------"
-	cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
+    log_info "$LOGFILE" "-------------------------------------"
+    cat "$TMPFILE_ARGS" | log_info "$LOGFILE"
 
-	# run script if possible (lock not existing)
-	run_main "$LOGFILE" "$SCRIPT_NAME"
-	# in case of error, send mail with extract of log file
-	[ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
+    # run script if possible (lock not existing)
+    run_main "$LOGFILE" "$SCRIPT_NAME"
+    # in case of error, send mail with extract of log file
+    [ "$?" -eq "2" ] && get_log_entries_ts "$LOGFILE" "$START_TIMESTAMP" | sendMail "$SCRIPT_NAME : issue occured during execution"
 fi
 
 $BIN_RM "$TMPFILE_ARGS"


### PR DESCRIPTION
* Use ` ` (spaces) instead of \t (tabs) for indentation (a tab was replaced by 4 spaces)
* Remove trailing tabs and spaces
* Start line comments after 2 space characters

Rationale: spaces are displayed equally on all IDEs