### PR TITLE
#34 - `backupData.sh`: New meaning of `fsDest` argument

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,17 @@ New features
 Changes
 -------
 
-- Remove support for several source ZFS file systems.
+ATTENTION: Thes changes BREAK the compatibility with the previous version of the command line interface.
+
+- backupData.sh: Change the meaning of the command line argument `fsDest` (#34)
+  Before the change the backup was done in `tank_backup/tank` if `fsSource=tank` and `fsDest=tank_backup`.
+  After he change the backup is done in `tank_backup` directly.
+
+  Rationale: This changes gives more control over the destination filesystem. 
+  This is required to support restoring a backup using `backupData.sh` 
+  (only source and destination filesystems must be slipped in the call)
+  
+- backupData.sh: Remove support for several source ZFS file systems.
   This (breaking change) is required in order to implement #34.
   Impact on the command line interface: 
   - `fsSource` identifies one single source file system
@@ -26,7 +36,8 @@ Changes
 Fixes
 -----
 
-- None
+- backupData.sh: Do not require anymore the destination filesystem to exist before starting the backup.
+  Only the destination ZPOOL must exist.
 
 Tested with
 -----------


### PR DESCRIPTION
Fixes #34

ATTENTION: This change BREAKS the compatibility with the previous version of the command line interface.

backupData.sh: Change the meaning of the command line argument `fsDest` (#34):

* Before the change the backup was done in `tank_backup/tank` if `fsSource=tank` and `fsDest=tank_backup`.
* After he change the backup is done in `tank_backup` directly.

Rationale: This gives more control over the destination FS.
This is required to support restoring a backup using `backupData.sh` (only source and destination filesystems must be slipped in the call)